### PR TITLE
Search fields by keyword arguments

### DIFF
--- a/musicbrainz.py
+++ b/musicbrainz.py
@@ -264,21 +264,52 @@ def get_work_by_id(id, includes=[]):
 # Searching
 
 def artist_search(query='', limit=None, offset=None, **fields):
+	"""Search for artists by a free-form `query` string and/or any of
+	the following keyword arguments specifying field queries:
+	arid, artist, sortname, type, begin, end, comment, alias, country,
+	gender, tag
+	"""
 	return _do_mb_search('artist', query, fields, limit, offset)
 
 def label_search(query='', limit=None, offset=None, **fields):
+	"""Search for labels by a free-form `query` string and/or any of
+	the following keyword arguments specifying field queries:
+	laid, label, sortname, type, code, country, begin, end, comment,
+	alias, tag
+	"""
 	return _do_mb_search('label', query, fields, limit, offset)
 
 def recording_search(query='', limit=None, offset=None, **fields):
+	"""Search for recordings by a free-form `query` string and/or any of
+	the following keyword arguments specifying field queries:
+	rid, recording, isrc, arid, artist, artistname, creditname, reid,
+	release, type, status, tracks, tracksrelease, dur, qdur, tnum,
+	position, tag
+	"""
 	return _do_mb_search('recording', query, fields, limit, offset)
 
 def release_search(query='', limit=None, offset=None, **fields):
+	"""Search for releases by a free-form `query` string and/or any of
+	the following keyword arguments specifying field queries:
+	reid, release, arid, artist, artistname, creditname, type, status,
+	tracks, tracksmedium, discids, discidsmedium, mediums, date, asin,
+	lang, script, country, date, label, catno, barcode, puid
+	"""
 	return _do_mb_search('release', query, fields, limit, offset)
 
 def release_group_search(query='', limit=None, offset=None, **fields):
+	"""Search for release groups by a free-form `query` string and/or
+	any of the following keyword arguments specifying field queries:
+	rgid, releasegroup, reid, release, arid, artist, artistname,
+	creditname, type, tag
+	"""
 	return _do_mb_search('release-group', query, fields, limit, offset)
 
 def work_search(query='', limit=None, offset=None, **fields):
+	"""Search for works by a free-form `query` string and/or any of
+	the following keyword arguments specifying field queries:
+	wid, work, iswc, type, arid, artist, alias, tag
+	"""
 	return _do_mb_search('work', query, fields, limit, offset)
 
 


### PR DESCRIPTION
Here's a change to the search functions that implements the idea we discussed earlier: "field" search parameters are now passed as keyword arguments to the search functions. The signatures are now like this:

```
def artist_search(query='', limit=None, offset=None, **fields)
```

which means you can combine a free-form query fragment with keyword arguments if you want. Sample queries include:

```
>>> musicbrainz.artist_search('magnetic fields', 2)
```

or, using specific fields for the query:

```
>>> musicbrainz.artist_search(artist='magnetic fields', limit=2)
```

The available keyword arguments are listed in the docstrings. (It would be nice to have a way of generating these automatically.)

I've also added documentation and done some reorganization in `musicbrainz.py`. Let me know if you disagree with any of the style changes; I don't feel strongly about any of them but I thought it might make the source a little easier to read.
