### PR TITLE
Unicode-related fix

### DIFF
--- a/musicbrainz.py
+++ b/musicbrainz.py
@@ -398,6 +398,10 @@ def _mb_request(path, method='GET', auth_required=False, client_required=False,
 	elif client_required:
 		args["client"] = _client
 
+	try:
+		args["query"] = args["query"].encode('utf-8')
+	except KeyError:
+		pass
 	# Construct the full URL for the request, including hostname and
 	# query string.
 	url = urlparse.urlunparse((


### PR DESCRIPTION
When using _mb_request with a unicode string containing non-ASCII
characters as query, the URL encoding fails because it tries to use the
ASCII encoding on those characters by default. By providing an 8-bits
string, it does not try to reencode it.

This bug is referenced in the issue tracker as #28

Cheers,

Simon
