### PR TITLE
Make unit tests compatible with Python 2.6

### DIFF
--- a/test/test_mbxml.py
+++ b/test/test_mbxml.py
@@ -1,6 +1,9 @@
-import unittest
 import os
 import sys
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
 sys.path.append(os.path.abspath(".."))
 from musicbrainzngs import mbxml
 

--- a/test/test_requests.py
+++ b/test/test_requests.py
@@ -1,6 +1,9 @@
-import unittest
 import os
 import sys
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
 import time
 sys.path.append(os.path.abspath(".."))
 from musicbrainzngs import musicbrainz


### PR DESCRIPTION
So far, while musicbrainzngs itself was compatible with Python 2.6, the
unit tests were written using features of unittest introduced by Python
2.7. This patch replaces unittest by unittest2 if the version of Python
is older than 2.7

I wrote this patch as part of my packaging work for Debian.
