### PR TITLE
Version number not updated

### DIFF
--- a/musicbrainzngs/musicbrainz.py
+++ b/musicbrainzngs/musicbrainz.py
@@ -16,7 +16,7 @@ import socket
 import xml.etree.ElementTree as etree
 from xml.parsers import expat
 
-_version = "0.2dev"
+_version = "0.3dev"
 _log = logging.getLogger("musicbrainzngs")
 
 

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,8 @@
 from distutils.core import setup
 from distutils.core import Command
 
+from musicbrainzngs.musicbrainz import _version
+
 class test(Command):
     description = "run automated tests"
     user_options = [
@@ -42,7 +44,7 @@ class test(Command):
 
 setup(
     name="musicbrainzngs",
-    version="0.3dev",
+    version=_version,
     description="python bindings for musicbrainz NGS webservice",
     author="Alastair Porter",
     author_email="alastair@porter.net.nz",


### PR DESCRIPTION
This patch lets setup.py pull the version number from musicbrainz.py.
That should prevent you from updating only one of them, next time you do a release. ;-)
