### PR TITLE
include search query tests, re #36, re #4

### DIFF
--- a/query.py
+++ b/query.py
@@ -4,7 +4,7 @@ import musicbrainzngs as m
 
 def main():
 	m.set_useragent("application", "0.01", "http://example.com")
-	print m.get_artist_by_id("952a4205-023d-4235-897c-6fdb6f58dfaa", [])
+	#print m.get_artist_by_id("952a4205-023d-4235-897c-6fdb6f58dfaa", [])
 	#print m.get_label_by_id("aab2e720-bdd2-4565-afc2-460743585f16")
 	#print m.get_release_by_id("e94757ff-2655-4690-b369-4012beba6114")
 	#print m.get_release_group_by_id("9377d65d-ffd5-35d6-b64d-43f86ef9188d")
@@ -14,6 +14,29 @@ def main():
 	#print m.get_releases_by_discid("BG.iuI50.qn1DOBAWIk8fUYoeHM-")
 	#print m.get_recordings_by_puid("070359fc-8219-e62b-7bfd-5a01e742b490")
 	#print m.get_recordings_by_isrc("GBAYE9300106")
+
+	def print_releases(result):
+		for release in result["release-list"]:
+			artistcredit = release["artist-credit"][0]["artist"]
+			artist = artistcredit["name"][:13]
+			title = release["title"][:35]
+			print "\tartist: %s \t release: %s" % (artist, title)
+
+	#simple queries:
+	print_releases(m.search_releases("Big in Japan",
+	artist="Guano Apes", limit=5))
+	#print_releases(m.search_releases(release="Big in Japan",
+	#	artist="Guano Apes", limit=5))
+
+	#phrase query:
+	#print_releases(m.search_releases('"Big in Japan"',
+	#	artist="Guano Apes", limit=5))
+
+	# direct queries
+	#print_releases(m.search_releases(
+	#	'"Big in Japan" AND artist:"Guano Apes"', limit=5))
+	#print_releases(m.search_releases(
+	#	'"Big in Japan" OR artist:"Guano Apes"', limit=5))
 
 	m.auth("", "")
 	#m.submit_barcodes({"e94757ff-2655-4690-b369-4012beba6114": "9421021463277"})


### PR DESCRIPTION
In order to conclude how we do searches, we should have some general test material to check.

There are some tests in the tests suit, but these don't test "concatenation" of various fields and/or a query string. When the search api is finishee, we can also add similar tests to the test suite

Additionally, there is no usage information for searches in the
examples.

These are the 5 main ways of searching for a release "Big in Japan"
from the artist "Guano Apes".
They currently result in these searches:

simple:
- Big in Japan artist:(Guano Apes)
  
  (note the missing quotation marks around "Big in Japan")
  same as: Big OR in OR Japan OR artist:(Guano OR Apes)
- release:(Big in Japan) artist:(Guano Apes)
  
  same as: relase:(Big OR in OR Japan) OR artist:(Guano OR Apes)

phrase:
- "Big in Japan" artist:(Guano Apes)
  
  same as: "Big in Japan" OR artist:(Guano OR Apes)
  note that we can't use phrases for the artist, because it is stripped

direct:
- "Big in Japan" AND artist:"Guano Apes"
  
  only results where both is the case
  not even remotely possible with simple searches atm
- "Big in Japan" OR artist:"Guano Apes"
  
  one of both is enough, but still use phrases
  the phrase search above comes closetst to this one

Explicit use of AND/OR in the query should only be used when no fields are set!
We could possibly lowercase the query when fields are set.
