### PR TITLE
use search fields as phrases, not groups

### DIFF
--- a/musicbrainzngs/musicbrainz.py
+++ b/musicbrainzngs/musicbrainz.py
@@ -524,7 +524,7 @@ def _do_mb_search(entity, query='', fields={}, limit=None, offset=None):
 		value = value.replace('\x00', '').strip()
 		value = value.lower() # Avoid binary operators like OR.
 		if value:
-			query_parts.append(u'%s:(%s)' % (key, value))
+			query_parts.append(u'%s:"%s"' % (key, value))
 	full_query = u' '.join(query_parts).strip()
 	if not full_query:
 		raise ValueError('at least one query term is required')


### PR DESCRIPTION
Currently each search field value is enclosed in parentheses,
effectively making it a group.
That is enough to make sure every word is searched in the context of
this field.
Additionally, quotation marks are stripped from the values of fields.

However, when you want to search for artist="The White Stripes"
you expect to get results including the whole artist name you
provided, not just one of these words.
Note, that (The White Stripes) is the same as (The OR White OR Stripes).

You could also prepend a plus sign to every word:
(+The +White +Stripes).
That would effectively search any permutation of these words.

In this commit the simple "enclose in parentheses" is implemented,
having a strict search for an order.

Please note that you can still use the query parameter to do fancy
stuff.
