### PR TITLE
Validate input to the rate limiting code. Fixes #42

### DIFF
--- a/musicbrainzngs/musicbrainz.py
+++ b/musicbrainzngs/musicbrainz.py
@@ -263,10 +263,10 @@ def set_rate_limit(rate_limit=True, new_interval=1.0, new_requests=1):
     global limit_interval
     global limit_requests
     global do_rate_limit
-    if new_interval == 0.0:
-        raise ValueError("new_interval can't be 0")
-    if new_requests == 0:
-        raise ValueError("new_requests can't be 0")
+    if new_interval <= 0.0:
+        raise ValueError("new_interval can't be less than 0")
+    if new_requests <= 0:
+        raise ValueError("new_requests can't be less than 0")
     limit_interval = new_interval
     limit_requests = new_requests
     do_rate_limit = rate_limit

--- a/test/test_requests.py
+++ b/test/test_requests.py
@@ -8,6 +8,34 @@ from musicbrainzngs import musicbrainz
 from test._common import Timecop
 
 
+class ArgumentTest(unittest.TestCase):
+    def test_invalid_args(self):
+        """ Passing invalid arguments to set_rate_limit should throw
+            an exception """
+        try:
+            musicbrainzngs.set_rate_limit(True, 1, 0)
+            self.fail("Required exception wasn't raised")
+        except ValueError, e:
+            self.assertTrue("new_requests" in e.message)
+
+        try:
+            musicbrainzngs.set_rate_limit(True, 0, 1)
+            self.fail("Required exception wasn't raised")
+        except ValueError, e:
+            self.assertTrue("new_interval" in e.message)
+
+        try:
+            musicbrainzngs.set_rate_limit(True, 1, -1)
+            self.fail("Required exception wasn't raised")
+        except ValueError, e:
+            self.assertTrue("new_requests" in e.message)
+
+        try:
+            musicbrainzngs.set_rate_limit(True, 0, -1)
+            self.fail("Required exception wasn't raised")
+        except ValueError, e:
+            self.assertTrue("new_interval" in e.message)
+
 class RateLimitingTest(unittest.TestCase):
     def setUp(self):
         self.cop = Timecop()
@@ -20,19 +48,6 @@ class RateLimitingTest(unittest.TestCase):
 
     def tearDown(self):
         self.cop.restore()
-
-    def test_invalid_args(self):
-        try:
-            musicbrainzngs.set_rate_limit(True, 1, 0)
-            self.fail("Required exception wasn't raised")
-        except ValueError, e:
-            self.assertTrue("new_requests" in e.message)
-
-        try:
-            musicbrainzngs.set_rate_limit(True, 0, 1)
-            self.fail("Required exception wasn't raised")
-        except ValueError, e:
-            self.assertTrue("new_interval" in e.message)
 
     def test_do_not_wait_initially(self):
         time1 = time.time()


### PR DESCRIPTION
Give an error if either parameter to the rate limiting code is bad. Also add an option to globally turn off limiting - good for people who want to run their own server, for example.
