### PR TITLE
examples: handle multiple artists in the credits

### DIFF
--- a/examples/releasesearch.py
+++ b/examples/releasesearch.py
@@ -21,8 +21,10 @@ musicbrainzngs.set_useragent(
 def show_release_details(rel):
     """Print some details about a release dictionary to stdout.
     """
-    artist_names = [c['artist']['name'] for c in rel['artist-credit']]
-    print("{}, by {}".format(rel['title'], ', '.join(artist_names)))
+    # "artist-credit-phrase" is a flat string of the credited artists
+    # joined with " + " or whatever is given by the server.
+    # You can also work with the "artist-credit" list manually.
+    print("{}, by {}".format(rel['title'], rel["artist-credit-phrase"]))
     if 'date' in rel:
         print("Released {} ({})".format(rel['date'], rel['status']))
     print("MusicBrainz ID: {}".format(rel['id']))


### PR DESCRIPTION
There can be multiple artists in the artist-credits that are separated
by a " + ". This is a string, not an artist object in itself.

An example is http://musicbrainz.org/release-group/742f2756-2b21-337a-baed-f9acc8e76daf
(13 by Noto + Yoko Tawada)

Test case:
`python examples/releasesearch.py Noto 13 | head`

The "| head" part is not crucial, but the 24 unreleated results (fuzzy search..) make it impossible to see the first result.
