### PR TITLE
Minor bug fixes for mbxml.py

### DIFF
--- a/musicbrainzngs/mbxml.py
+++ b/musicbrainzngs/mbxml.py
@@ -317,7 +317,8 @@ def parse_recording(recording):
 	             "rating": parse_rating,
 	             "puid-list": parse_external_id_list,
 	             "isrc-list": parse_external_id_list,
-	             "echoprint-list": parse_external_id_list}
+	             "echoprint-list": parse_external_id_list,
+	             "relation-list": parse_relation_list}
 
 	result.update(parse_attributes(attribs, recording))
 	result.update(parse_elements(elements, recording))
@@ -343,7 +344,8 @@ def parse_work(work):
 	inner_els = {"tag-list": parse_tag_list,
 	             "user-tag-list": parse_tag_list,
 	             "rating": parse_rating,
-	             "alias-list": parse_alias_list}
+	             "alias-list": parse_alias_list,
+	             "relation-list": parse_relation_list}
 
 	result.update(parse_attributes(attribs, work))
 	result.update(parse_elements(elements, work))


### PR DESCRIPTION
Greetings!

I've been using python-musicbrainz-ngs for a personal project (custom scripts for tagging/organizing my extensive classical music collection) and I ran into a few problems in the process. The first had to do with the artist-credit-phrase string not matching what would be displayed on musicbrainz.org, and the second was that work and recording relations wouldn't be parsed when retrieved with "recording-level-rels" and "work-level-rels".

I've fixed both issues; the patches are small.

--Galen Hazelwood
