### PR TITLE
Log to _log.debug elements that go unparsed.

### DIFF
--- a/musicbrainzngs/mbxml.py
+++ b/musicbrainzngs/mbxml.py
@@ -118,6 +118,11 @@ def parse_inner(inner_els, element):
 			_log.debug("in <%s>, not delegating <%s>", fixtag(element.tag, NS_MAP)[0], t)
 	return result
 
+def _log_unmatched(parsed, elem, func):
+    unmatched = [fixtag(i.tag,NS_MAP)[0] for i in elem if fixtag(i.tag,NS_MAP)[0].split(':')[1] not in parsed]
+    if len(unmatched) > 0:
+        _log.debug("Didn't handle %s in %s", unmatched, func)
+
 def parse_message(message):
 	tree = util.bytes_to_elementtree(message)
 	root = tree.getroot()
@@ -146,9 +151,7 @@ def parse_message(message):
 	                  "message": parse_response_message
 	                  }
 	result.update(parse_inner(valid_elements, root))
-	unmatched = [fixtag(i.tag,NS_MAP)[0] for i in root if fixtag(i.tag,NS_MAP)[0].split(':')[1] not in valid_elements.keys()]
-	if len(unmatched) > 0:
-		_log.debug("Didn't handle %s in parse_message", unmatched)
+	_log_unmatched(valid_elements.keys(), root, 'parse_message')
 	return result
 
 def parse_response_message(message):
@@ -166,9 +169,8 @@ def parse_collection(collection):
 	result.update(parse_elements(elements, collection))
 	result.update(parse_inner(inner_els, collection))
 
-	unmatched = [fixtag(i.tag,NS_MAP)[0] for i in collection if fixtag(i.tag,NS_MAP)[0].split(':')[1] not in (elements + inner_els.keys())]
-	if len(unmatched) > 0:
-		_log.debug("Didn't handle %s in parse_collection", unmatched)
+
+	_log_unmatched((elements + inner_els.keys()), collection, 'parse_collection')
 	return result
 
 def parse_collection_release_list(rl):
@@ -203,9 +205,7 @@ def parse_artist(artist):
     result.update(parse_elements(elements, artist))
     result.update(parse_inner(inner_els, artist))
 
-    unmatched = [fixtag(i.tag,NS_MAP)[0] for i in artist if fixtag(i.tag,NS_MAP)[0].split(':')[1] not in (elements + inner_els.keys())]
-    if len(unmatched) > 0:
-        _log.debug("Didn't handle %s in parse_artist", unmatched)
+    _log_unmatched((elements + inner_els.keys()), artist, 'parse_artist')
     return result
 
 def parse_label_list(ll):
@@ -228,9 +228,7 @@ def parse_label(label):
     result.update(parse_elements(elements, label))
     result.update(parse_inner(inner_els, label))
 
-    unmatched = [fixtag(i.tag,NS_MAP)[0] for i in label if fixtag(i.tag,NS_MAP)[0].split(':')[1] not in (elements + inner_els.keys())]
-    if len(unmatched) > 0:
-        _log.debug("Didn't handle %s in parse_label", unmatched)
+    _log_unmatched((elements + inner_els.keys()), label, 'parse_label')
     return result
 
 def parse_relation_list(rl):
@@ -255,9 +253,7 @@ def parse_relation(relation):
     result.update(parse_elements(elements, relation))
     result.update(parse_inner(inner_els, relation))
 
-    unmatched = [fixtag(i.tag,NS_MAP)[0] for i in relation if fixtag(i.tag,NS_MAP)[0].split(':')[1] not in (elements + inner_els.keys())]
-    if len(unmatched) > 0:
-        _log.debug("Didn't handle %s in parse_relation", unmatched)
+    _log_unmatched((elements + inner_els.keys()), relation, 'parse_relation')
     return result
 
 def parse_release(release):
@@ -277,9 +273,7 @@ def parse_release(release):
 	if "artist-credit" in result:
 		result["artist-credit-phrase"] = make_artist_credit(result["artist-credit"])
 
-	unmatched = [fixtag(i.tag,NS_MAP)[0] for i in release if fixtag(i.tag,NS_MAP)[0].split(':')[1] not in (elements + inner_els.keys())]
-	if len(unmatched) > 0:
-		_log.debug("Didn't handle %s in parse_release", unmatched)
+	_log_unmatched((elements + inner_els.keys()), release, 'parse_release')
 	return result
 
 def parse_medium_list(ml):
@@ -293,9 +287,7 @@ def parse_medium(medium):
 
 	result.update(parse_elements(elements, medium))
 	result.update(parse_inner(inner_els, medium))
-	unmatched = [fixtag(i.tag,NS_MAP)[0] for i in medium if fixtag(i.tag,NS_MAP)[0].split(':')[1] not in (elements + inner_els.keys())]
-	if len(unmatched) > 0:
-		_log.debug("Didn't handle %s in parse_medium", unmatched)
+	_log_unmatched((elements + inner_els.keys()), medium, 'parse_medium')
 	return result
 
 def parse_disc_list(dl):
@@ -320,9 +312,7 @@ def parse_release_group(rg):
 	if "artist-credit" in result:
 		result["artist-credit-phrase"] = make_artist_credit(result["artist-credit"])
 
-	unmatched = [fixtag(i.tag,NS_MAP)[0] for i in rg if fixtag(i.tag,NS_MAP)[0].split(':')[1] not in (elements + inner_els.keys())]
-	if len(unmatched) > 0:
-		_log.debug("Didn't handle %s in parse_release_group", unmatched)
+	_log_unmatched((elements + inner_els.keys()), rg, 'parse_release_group')
 	return result
 
 def parse_recording(recording):
@@ -345,9 +335,7 @@ def parse_recording(recording):
 	if "artist-credit" in result:
 		result["artist-credit-phrase"] = make_artist_credit(result["artist-credit"])
 
-	unmatched = [fixtag(i.tag,NS_MAP)[0] for i in recording if fixtag(i.tag,NS_MAP)[0].split(':')[1] not in (elements + inner_els.keys())]
-	if len(unmatched) > 0:
-		_log.debug("Didn't handle %s in parse_recording", unmatched)
+	_log_unmatched((elements + inner_els.keys()), recording, 'parse_recording')
 	return result
 
 def parse_external_id_list(pl):
@@ -374,9 +362,7 @@ def parse_work(work):
     result.update(parse_elements(elements, work))
     result.update(parse_inner(inner_els, work))
 
-    unmatched = [fixtag(i.tag,NS_MAP)[0] for i in work if fixtag(i.tag,NS_MAP)[0].split(':')[1] not in (elements + inner_els.keys())]
-    if len(unmatched) > 0:
-        _log.debug("Didn't handle %s in parse_work", unmatched)
+    _log_unmatched((elements + inner_els.keys()), work, 'parse_work')
     return result
 
 def parse_disc(disc):
@@ -389,9 +375,7 @@ def parse_disc(disc):
 	result.update(parse_elements(elements, disc))
 	result.update(parse_inner(inner_els, disc))
 
-	unmatched = [fixtag(i.tag,NS_MAP)[0] for i in disc if fixtag(i.tag,NS_MAP)[0].split(':')[1] not in (elements + inner_els.keys())]
-	if len(unmatched) > 0:
-		_log.debug("Didn't handle %s in parse_disc", unmatched)
+	_log_unmatched((elements + inner_els.keys()), disc, 'parse_disc')
 	return result
 
 def parse_release_list(rl):
@@ -414,9 +398,7 @@ def parse_puid(puid):
 	result.update(parse_attributes(attribs, puid))
 	result.update(parse_inner(inner_els, puid))
 
-	unmatched = [fixtag(i.tag,NS_MAP)[0] for i in puid if fixtag(i.tag,NS_MAP)[0].split(':')[1] not in inner_els.keys()]
-	if len(unmatched) > 0:
-		_log.debug("Didn't handle %s in parse_puid", unmatched)
+	_log_unmatched(inner_els.keys(), puid, 'parse_puid')
 	return result
 
 def parse_recording_list(recs):
@@ -442,9 +424,7 @@ def parse_name_credit(nc):
 	result.update(parse_elements(elements, nc))
 	result.update(parse_inner(inner_els, nc))
 
-	unmatched = [fixtag(i.tag,NS_MAP)[0] for i in nc if fixtag(i.tag,NS_MAP)[0].split(':')[1] not in (elements + inner_els.keys())]
-	if len(unmatched) > 0:
-		_log.debug("Didn't handle %s in parse_name_credit", unmatched)
+	_log_unmatched((elements + inner_els.keys()), nc, 'parse_name_credit')
 	return result
 
 def parse_label_info_list(lil):
@@ -461,9 +441,7 @@ def parse_label_info(li):
 
 	result.update(parse_elements(elements, li))
 	result.update(parse_inner(inner_els, li))
-	unmatched = [fixtag(i.tag,NS_MAP)[0] for i in li if fixtag(i.tag,NS_MAP)[0].split(':')[1] not in (elements + inner_els.keys())]
-	if len(unmatched) > 0:
-		_log.debug("Didn't handle %s in parse_label_info", unmatched)
+	_log_unmatched((elements + inner_els.keys()), li, 'parse_label_info')
 	return result
 
 def parse_track_list(tl):
@@ -479,9 +457,7 @@ def parse_track(track):
 
 	result.update(parse_elements(elements, track))
 	result.update(parse_inner(inner_els, track))
-	unmatched = [fixtag(i.tag,NS_MAP)[0] for i in track if fixtag(i.tag,NS_MAP)[0].split(':')[1] not in (elements + inner_els.keys())]
-	if len(unmatched) > 0:
-		_log.debug("Didn't handle %s in parse_track", unmatched)
+	_log_unmatched((elements + inner_els.keys()), track, 'parse_track')
 	return result
 
 def parse_tag_list(tl):
@@ -495,9 +471,7 @@ def parse_tag(tag):
 	result.update(parse_attributes(attribs, tag))
 	result.update(parse_elements(elements, tag))
 
-	unmatched = [fixtag(i.tag,NS_MAP)[0] for i in tag if fixtag(i.tag,NS_MAP)[0].split(':')[1] not in elements]
-	if len(unmatched) > 0:
-		_log.debug("Didn't handle %s in parse_tag", unmatched)
+	_log_unmatched(elements, tag, 'parse_tag')
 	return result
 
 def parse_rating(rating):


### PR DESCRIPTION
This is at least a start at letting us know when we're missing things. For example, we're not handling 'disambiguation' in parse_work, apparently.

To test:

> import logging
> logging.basicConfig(level=logging.DEBUG)
> import musicbrainzngs as m
> m.set_useragent("testing-log-debug", "none")
> m.get_work_by_id("a5409ad5-ab43-3b92-8199-35b7ae92c505")
