### PR TITLE
Minor fix: artist-credit entries attached to track structures

### DIFF
--- a/musicbrainzngs/mbxml.py
+++ b/musicbrainzngs/mbxml.py
@@ -433,10 +433,14 @@ def parse_track_list(tl):
 def parse_track(track):
 	result = {}
 	elements = ["number", "position", "title", "length"]
-	inner_els = {"recording": parse_recording}
+	inner_els = {"recording": parse_recording,
+	             "artist-credit": parse_artist_credit}
 
 	result.update(parse_elements(elements, track))
 	result.update(parse_inner(inner_els, track))
+	if "artist-credit" in result:
+		result["artist-credit-phrase"] = make_artist_credit(result["artist-credit"])
+
 	return result
 
 def parse_tag_list(tl):


### PR DESCRIPTION
Track records, in addition to title, can have an artist field as well. This is useful
for things like the Classical Style Guide, which says the track artist should be the
composer but the recording artist should be the performers.

Signed-off-by: Galen Hazelwood galenhz@gmail.com
