### PR TITLE
Added 'aliases' to more entities in VALID_INCLUDES

### DIFF
--- a/musicbrainzngs/musicbrainz.py
+++ b/musicbrainzngs/musicbrainz.py
@@ -41,20 +41,20 @@ VALID_INCLUDES = {
 	    "discids", "media", "artist-credits",
 	    "tags", "user-tags", "ratings", "user-ratings", # misc
 		"artist-rels", "label-rels", "recording-rels", "release-rels",
-		"release-group-rels", "url-rels", "work-rels", "annotation"
+		"release-group-rels", "url-rels", "work-rels", "annotation", "aliases"
 	],
 	'release': [
 		"artists", "labels", "recordings", "release-groups", "media",
 		"artist-credits", "discids", "puids", "echoprints", "isrcs",
 		"artist-rels", "label-rels", "recording-rels", "release-rels",
 		"release-group-rels", "url-rels", "work-rels", "recording-level-rels",
-		"work-level-rels", "annotation"
+		"work-level-rels", "annotation", "aliases"
 	],
 	'release-group': [
 		"artists", "releases", "discids", "media",
 		"artist-credits", "tags", "user-tags", "ratings", "user-ratings", # misc
 		"artist-rels", "label-rels", "recording-rels", "release-rels",
-		"release-group-rels", "url-rels", "work-rels", "annotation"
+		"release-group-rels", "url-rels", "work-rels", "annotation", "aliases"
 	],
 	'work': [
 		"artists", # Subqueries


### PR DESCRIPTION
The MusicBrainz API now supports _aliases_ as a _inc=_ argument for lookups: http://musicbrainz.org/doc/Development/XML_Web_Service/Version_2#Misc_inc.3D_arguments

This patch adds support for that to VALID_INCLUDES for the following entity types:

**recording**
example: http://musicbrainz.org/ws/2/recording/e87e51c3-2123-448b-8644-885756cfa28f?inc=artists+aliases

**release-group**
example: http://musicbrainz.org/ws/2/release-group/bdaeec2d-94f1-46b5-91f3-340ec6939c66?inc=artists+aliases

**release**
example: http://musicbrainz.org/ws/2/release/a6286a41-5b4f-47d4-825f-a52fac1d343f?inc=artists+aliases+artist-credits+labels

_aliases_ is only valid when used with _artist_, _label_, or _work_ entities (or includes), however it is ignored when they are not present, example: http://musicbrainz.org/ws/2/recording/e87e51c3-2123-448b-8644-885756cfa28f?inc=aliases
