### PR TITLE
fix _check_filter_and_make_params() usage

### DIFF
--- a/musicbrainzngs/musicbrainz.py
+++ b/musicbrainzngs/musicbrainz.py
@@ -734,19 +734,19 @@ def search_works(query='', limit=None, offset=None, strict=False, **fields):
 
 # Lists of entities
 def get_releases_by_discid(id, includes=[], release_status=[], release_type=[]):
-	params = _check_filter_and_make_params(includes, release_status, release_type=release_type)
+	params = _check_filter_and_make_params("release", includes, release_status, release_type=release_type)
 	return _do_mb_query("discid", id, includes, params)
 
 def get_recordings_by_echoprint(echoprint, includes=[], release_status=[], release_type=[]):
-	params = _check_filter_and_make_params(includes, release_status, release_type)
+	params = _check_filter_and_make_params("recording", includes, release_status, release_type)
 	return _do_mb_query("echoprint", echoprint, includes, params)
 
 def get_recordings_by_puid(puid, includes=[], release_status=[], release_type=[]):
-	params = _check_filter_and_make_params(includes, release_status, release_type)
+	params = _check_filter_and_make_params("recording", includes, release_status, release_type)
 	return _do_mb_query("puid", puid, includes, params)
 
 def get_recordings_by_isrc(isrc, includes=[], release_status=[], release_type=[]):
-	params = _check_filter_and_make_params(includes, release_status, release_type)
+	params = _check_filter_and_make_params("recording", includes, release_status, release_type)
 	return _do_mb_query("isrc", isrc, includes, params)
 
 def get_works_by_iswc(iswc, includes=[]):


### PR DESCRIPTION
The `_check_filter_and_make_params()` function wants an entitiy as first argument.
The usage is correct in single entitities, but wasn't in entity lists.

The problem was introduced in 86110dc2886a74d85dc349d11a2f7672e34ba035 where the function parameters were changed.
That gave
`TypeError: _check_filter_and_make_params() takes at least 2 arguments (2 given)`
when using get_releases_by_discid() and others.

The problem was hidden with the fix in 4260ed51273babb909a27fe07d68923158d2e9ec
No TypeError anymore, but the entity was set to the includes, includes were empty in return.

For single entity requests this was fixed correctly in 088562d764db85355fb075c30d6b5590a804bb2e

This now finally fixes this for entity list requests.
