### PR TITLE
Authentication using non-ascii password not working

### DIFF
--- a/musicbrainzngs/musicbrainz.py
+++ b/musicbrainzngs/musicbrainz.py
@@ -372,26 +372,25 @@ class _DigestAuthHandler(compat.HTTPDigestAuthHandler):
 
         return compat.HTTPDigestAuthHandler.get_authorization (self, req, chal)
 
-    def encode_8559(self, msg):
-        """The MusicBrainz server also accepts
-        latin1/iso-8559-1 encoded passwords."""
+    def _encode_utf8(self, msg):
+        """The MusicBrainz server also accepts UTF-8 encoded passwords."""
         encoding = sys.stdin.encoding or locale.getpreferredencoding()
         try:
             # This works on Python 2 (msg in bytes)
             msg = msg.decode(encoding)
         except AttributeError:
-            # on Python 3 (msg is already unicode)
+            # on Python 3 (msg is already in unicode)
             pass
-        return msg.encode("iso-8859-1")
+        return msg.encode("utf-8")
 
     def get_algorithm_impls(self, algorithm):
         # algorithm should be case-insensitive according to RFC2617
         algorithm = algorithm.upper()
         # lambdas assume digest modules are imported at the top level
         if algorithm == 'MD5':
-            H = lambda x: hashlib.md5(self.encode_8559(x)).hexdigest()
+            H = lambda x: hashlib.md5(self._encode_utf8(x)).hexdigest()
         elif algorithm == 'SHA':
-            H = lambda x: hashlib.sha1(self.encode_8559(x)).hexdigest()
+            H = lambda x: hashlib.sha1(self._encode_utf8(x)).hexdigest()
         # XXX MD5-sess
         KD = lambda s, d: H("%s:%s" % (s, d))
         return H, KD


### PR DESCRIPTION
This is the upstream report for JonnyJD/musicbrainz-isrcsubmit#58.

Summary:
It is a bit vague how this is supposed to work in general, but working with the musicbrainz server using the "latin1" encoding seems to work.
For Python 2 we can just force the encoding of `password` (and potentially `user`) to "latin1".
On Python 3 these are supposed to be unicode and will be decoded to unicode in urllib. Subclassing `HTTPDigestAuthHandler` could work.

One could argue if this is an upstream urllib bug or not.
We should at least try to submit it. This needs a bit preparation, though.

There is a test script available at:
https://gist.github.com/JonnyJD/5429281 (password_test.py)
You either have an account on musicbrainz.org with non-ascii characters or you can change the hostname in the top of the file to test.musicbrainz.org and fix somehting up there.
The Python 2 case is fixed in the test script already, but this should be implemented in python-musicbrainz-ngs instead.
