### PR TITLE
Relatable type deduplication

### DIFF
--- a/musicbrainzngs/musicbrainz.py
+++ b/musicbrainzngs/musicbrainz.py
@@ -79,10 +79,13 @@ VALID_BROWSE_INCLUDES = {
     'releases': ["artist-credits", "labels", "recordings",
                 "release-groups", "media", "discids"] + RELATION_INCLUDES,
     'recordings': ["artist-credits", "tags", "ratings", "user-tags",
-                  "user-ratings"],
-    'labels': ["aliases", "tags", "ratings", "user-tags", "user-ratings"],
-    'artists': ["aliases", "tags", "ratings", "user-tags", "user-ratings"],
-    'release-groups': ["artist-credits", "tags", "ratings", "user-tags", "user-ratings"]
+                  "user-ratings"] + RELATION_INCLUDES,
+    'labels': ["aliases", "tags", "ratings",
+               "user-tags", "user-ratings"] + RELATION_INCLUDES,
+    'artists': ["aliases", "tags", "ratings",
+                "user-tags", "user-ratings"] + RELATION_INCLUDES,
+    'release-groups': ["artist-credits", "tags", "ratings",
+                       "user-tags", "user-ratings"] + RELATION_INCLUDES
 }
 
 #: These can be used to filter whenever releases are includes or browsed


### PR DESCRIPTION
We spelled out every valid relatable type in VALID_INCLUDES and VALID_BROWSE_INCLUDES every time. And of course, with the addition of areas, we were missing some. This makes it so we just maintain one list of all the valid types to relate to. (as an aside, I think VALID_BROWSE_INCLUDES is missing rels on some entities that support them. but anyway)

Whether this or my other PR gets merged first they'll need some manual fixing-up, since they overlap for URLs, but that seems fine.
