### PR TITLE
Allow browsing releases by track_artist

### DIFF
--- a/musicbrainzngs/musicbrainz.py
+++ b/musicbrainzngs/musicbrainz.py
@@ -991,11 +991,14 @@ def browse_recordings(artist=None, release=None, includes=[],
                         limit, offset, params)
 
 @_docstring('releases', browse=True)
-def browse_releases(artist=None, label=None, recording=None,
+def browse_releases(artist=None, track_artist=None, label=None, recording=None,
                     release_group=None, release_status=[], release_type=[],
                     includes=[], limit=None, offset=None):
     """Get all releases linked to an artist, a label, a recording
     or a release group. You need to give one MusicBrainz ID.
+
+    You can also browse by `track_artist`, which gives all releases where some
+    tracks are attributed to that artist, but not the whole release.
 
     You can filter by :data:`musicbrainz.VALID_RELEASE_TYPES` or
     :data:`musicbrainz.VALID_RELEASE_STATUSES`.
@@ -1004,6 +1007,7 @@ def browse_releases(artist=None, label=None, recording=None,
     # track_artist param doesn't work yet
     valid_includes = VALID_BROWSE_INCLUDES['releases']
     params = {"artist": artist,
+              "track_artist": track_artist,
               "label": label,
               "recording": recording,
               "release-group": release_group}


### PR DESCRIPTION
This would browse all releases where the artist is one of the track artists, but not the overall release artist (various artist releases).

Documented here: http://musicbrainz.org/doc/Development/XML%20Web%20Service/Version%202#Linked_entities

Example:
http://musicbrainz.org/ws/2/release?track_artist=65f4f0c5-ef9e-490c-aee3-909e7ae6b2ab
