### PR TITLE
Move the contribution guidelines to their own file.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,7 @@
+# Contribute
+
+1. Fork the [repository](https://github.com/alastair/python-musicbrainzngs>)
+   on Github.
+2. Make and test whatever changes you desire.
+3. Signoff and commit your changes using ``git commit -s``.
+4. Send a pull request.

--- a/README.rst
+++ b/README.rst
@@ -32,11 +32,10 @@ More documentation is available at
 Contribute
 **********
 
-1. Fork the `repository <https://github.com/alastair/python-musicbrainzngs>`_
-   on Github.
-2. Make and test whatever changes you desire.
-3. Signoff and commit your changes using ``git commit -s``.
-4. Send a pull request.
+If you want to contribute to this repository, please read `the
+contribution guidelines
+<https://github.com/alastair/python-musicbrainzngs/CONTRIBUTING.md>`_ first.
+
 
 Authors
 *******


### PR DESCRIPTION
This is to make GitHub show them when people open pull requests.
Unfortunately only Markdown files are supported [0] for this feature.

[0] https://github.com/blog/1184-contributing-guidelines

Signed-off-by: Wieland Hoffmann <themineo@gmail.com>