### PR TITLE
Support for `data-track-list' XML tag.

### DIFF
--- a/musicbrainzngs/mbxml.py
+++ b/musicbrainzngs/mbxml.py
@@ -396,7 +396,8 @@ def parse_medium(medium):
     elements = ["position", "format", "title"]
     inner_els = {"disc-list": parse_disc_list,
                  "pregap": parse_track,
-                 "track-list": parse_track_list}
+                 "track-list": parse_track_list,
+                 "data-track-list": parse_track_list}
 
     result.update(parse_elements(elements, inner_els, medium))
     return result


### PR DESCRIPTION
Hi,

On some releases, the data track of the medium (CD, usually) may contain audio/video files which MusicBrainz takes into account as actual tracks in the release. See for instance [this release](https://musicbrainz.org/release/9ce41d09-40e4-4d33-af0c-7fed1e558dba).

When this is the case, the extra tracks are listed under a `data-track-list` XML element, as per the [MusicBrainz schema](https://github.com/metabrainz/mmd-schema/blob/a43198f5ffdd6b726988481628aa08a05deccb6d/schema/musicbrainz_mmd-2.0.rng#L2051).

This patch adds support for this element, which is parsed as a regular track list element.

Cheers,
Jérémie.