### PR TITLE
Allow single items as strings instead of a list of one string

### DIFF
--- a/musicbrainzngs/musicbrainz.py
+++ b/musicbrainzngs/musicbrainz.py
@@ -1054,6 +1054,7 @@ def get_works_by_iswc(iswc, includes=[]):
 
 
 def _browse_impl(entity, includes, valid_includes, limit, offset, params, release_status=[], release_type=[]):
+    includes = includes if isinstance(includes, list) else [includes]
     _check_includes_impl(includes, valid_includes)
     p = {}
     for k,v in params.items():

--- a/musicbrainzngs/musicbrainz.py
+++ b/musicbrainzngs/musicbrainz.py
@@ -1235,11 +1235,17 @@ def submit_tags(**kwargs):
     Takes parameters named e.g. 'artist_tags', 'recording_tags', etc.,
     and of the form:
     {entity_id1: [tag1, ...], ...}
+    If you only have one tag for an entity you can use a string instead
+    of a list.
 
     The user's tags for each entity will be set to that list, adding or
     removing tags as necessary. Submitting an empty list for an entity
     will remove all tags for that entity by the user.
     """
+    for k, v in kwargs.items():
+        for id, tags in v.items():
+            kwargs[k][id] = tags if isinstance(tags, list) else [tags]
+
     query = mbxml.make_tag_request(**kwargs)
     return _do_mb_post("tag", query)
 

--- a/test/test_browse.py
+++ b/test/test_browse.py
@@ -1,0 +1,30 @@
+import unittest
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import musicbrainzngs
+from musicbrainzngs import musicbrainz
+from test import _common
+
+class BrowseTest(unittest.TestCase):
+
+    def setUp(self):
+        self.opener = _common.FakeOpener("<response/>")
+        musicbrainzngs.compat.build_opener = lambda *args: self.opener
+
+    def test_browse(self):
+        area = "74e50e58-5deb-4b99-93a2-decbb365c07f"
+        musicbrainzngs.browse_events(area=area)
+        self.assertEqual("http://musicbrainz.org/ws/2/event/?area=74e50e58-5deb-4b99-93a2-decbb365c07f", self.opener.get_url())
+
+    def test_browse_includes(self):
+        area = "74e50e58-5deb-4b99-93a2-decbb365c07f"
+        musicbrainzngs.browse_events(area=area, includes=["aliases", "area-rels"])
+        self.assertEqual("http://musicbrainz.org/ws/2/event/?area=74e50e58-5deb-4b99-93a2-decbb365c07f&inc=aliases+area-rels", self.opener.get_url())
+
+    def test_browse_single_include(self):
+        area = "74e50e58-5deb-4b99-93a2-decbb365c07f"
+        musicbrainzngs.browse_events(area=area, includes="aliases")
+        self.assertEqual("http://musicbrainz.org/ws/2/event/?area=74e50e58-5deb-4b99-93a2-decbb365c07f&inc=aliases", self.opener.get_url())
+

--- a/test/test_mbxml.py
+++ b/test/test_mbxml.py
@@ -13,6 +13,17 @@ class MbXML(unittest.TestCase):
         xml = mbxml.make_barcode_request({'trid':'12345'})
         self.assertEqual(expected, xml)
 
+    def test_make_tag_request(self):
+        expected = (b'<ns0:metadata xmlns:ns0="http://musicbrainz.org/ns/mmd-2.0#">'
+                    b'<ns0:artist-list><ns0:artist ns0:id="mbid">'
+                    b'<ns0:user-tag-list>'
+                    b'<ns0:user-tag><ns0:name>one</ns0:name></ns0:user-tag>'
+                    b'<ns0:user-tag><ns0:name>two</ns0:name></ns0:user-tag>'
+                    b'</ns0:user-tag-list></ns0:artist>'
+                    b'</ns0:artist-list></ns0:metadata>')
+        xml = mbxml.make_tag_request(artist_tags={"mbid": ["one", "two"]})
+        self.assertEqual(expected, xml)
+
     def test_read_error(self):
         error = '<?xml version="1.0" encoding="UTF-8"?><error><text>Invalid mbid.</text><text>For usage, please see: http://musicbrainz.org/development/mmd</text></error>'
         parts = mbxml.get_error_message(error)

--- a/test/test_submit.py
+++ b/test/test_submit.py
@@ -1,0 +1,32 @@
+import unittest
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import musicbrainzngs
+from musicbrainzngs import musicbrainz
+from test import _common
+
+class SubmitTest(unittest.TestCase):
+    def test_submit_tags(self):
+        self.opener = _common.FakeOpener("<response/>")
+        musicbrainzngs.compat.build_opener = lambda *args: self.opener
+        def make_xml(**kwargs):
+            self.assertEqual({'artist_tags': {'mbid': ['one', 'two']}}, kwargs)
+        oldmake_tag_request = musicbrainz.mbxml.make_tag_request
+        musicbrainz.mbxml.make_tag_request = make_xml
+
+        musicbrainz.submit_tags(artist_tags={"mbid": ["one", "two"]})
+        musicbrainz.mbxml.make_tag_request = oldmake_tag_request
+
+    def test_submit_single_tag(self):
+        self.opener = _common.FakeOpener("<response/>")
+        musicbrainzngs.compat.build_opener = lambda *args: self.opener
+        def make_xml(**kwargs):
+            self.assertEqual({'artist_tags': {'mbid': ['single']}}, kwargs)
+        oldmake_tag_request = musicbrainz.mbxml.make_tag_request
+        musicbrainz.mbxml.make_tag_request = make_xml
+
+        musicbrainz.submit_tags(artist_tags={"mbid": "single"})
+        musicbrainz.mbxml.make_tag_request = oldmake_tag_request
+


### PR DESCRIPTION
For browse requests allow an include to be a string (#184). The query code would have accepted this, but the includes checking code didn't.
Allow tag submissions to consist of `{"mbid": "tag"}` instead of requiring tags to always be in a list