### PR TITLE
Browse

### DIFF
--- a/musicbrainzngs/musicbrainz.py
+++ b/musicbrainzngs/musicbrainz.py
@@ -83,14 +83,15 @@ VALID_INCLUDES = {
     'collection': ['releases'],
 }
 VALID_BROWSE_INCLUDES = {
-    'release': ["artist-credits", "labels", "recordings", "isrcs",
-                "release-groups", "media", "discids"] + RELATION_INCLUDES,
-    'recording': ["artist-credits", "isrcs"] + TAG_INCLUDES + RATING_INCLUDES + RELATION_INCLUDES,
-    'label': ["aliases"] + TAG_INCLUDES + RATING_INCLUDES + RELATION_INCLUDES,
     'artist': ["aliases"] + TAG_INCLUDES + RATING_INCLUDES + RELATION_INCLUDES,
     'event': ["aliases"] + TAG_INCLUDES + RATING_INCLUDES + RELATION_INCLUDES,
+    'label': ["aliases"] + TAG_INCLUDES + RATING_INCLUDES + RELATION_INCLUDES,
+    'recording': ["artist-credits", "isrcs"] + TAG_INCLUDES + RATING_INCLUDES + RELATION_INCLUDES,
+    'release': ["artist-credits", "labels", "recordings", "isrcs",
+                "release-groups", "media", "discids"] + RELATION_INCLUDES,
+    'release-group': ["artist-credits"] + TAG_INCLUDES + RATING_INCLUDES + RELATION_INCLUDES,
     'url': RELATION_INCLUDES,
-    'release-group': ["artist-credits"] + TAG_INCLUDES + RATING_INCLUDES + RELATION_INCLUDES
+    'work': ["aliases", "annotation"] + TAG_INCLUDES + RATING_INCLUDES + RELATION_INCLUDES,
 }
 
 #: These can be used to filter whenever releases are includes or browsed
@@ -1080,15 +1081,15 @@ def _browse_impl(entity, includes, limit, offset, params, release_status=[], rel
 # and the test in _do_mb_query will pass anyway.
 @_docstring_browse("artist")
 def browse_artists(recording=None, release=None, release_group=None,
-                   includes=[], limit=None, offset=None):
+                   work=None, includes=[], limit=None, offset=None):
     """Get all artists linked to a recording, a release or a release group.
     You need to give one MusicBrainz ID.
 
     *Available includes*: {includes}"""
-    # optional parameter work?
     params = {"recording": recording,
               "release": release,
-              "release-group": release_group}
+              "release-group": release_group,
+              "work": work}
     return _browse_impl("artist", includes, limit, offset, params)
 
 @_docstring_browse("event")
@@ -1167,6 +1168,14 @@ def browse_urls(resource=None, includes=[], limit=None, offset=None):
     *Available includes*: {includes}"""
     params = {"resource": resource}
     return _browse_impl("url", includes, limit, offset, params)
+
+@_docstring_browse("work")
+def browse_works(artist=None, includes=[], limit=None, offset=None):
+    """Get all works linked to an artist
+
+    *Available includes*: {includes}"""
+    params = {"artist": artist}
+    return _browse_impl("work", includes, limit, offset, params)
 
 # Collections
 def get_collections():

--- a/musicbrainzngs/musicbrainz.py
+++ b/musicbrainzngs/musicbrainz.py
@@ -262,21 +262,27 @@ def _check_filter_and_make_params(entity, includes, release_status=[], release_t
         params["type"] = "|".join(release_type)
     return params
 
-def _docstring(entity, browse=False):
+def _docstring_get(entity):
+    includes = list(VALID_INCLUDES.get(entity, []))
+    return _docstring_impl("includes", includes)
+
+def _docstring_browse(entity):
+    includes = list(VALID_BROWSE_INCLUDES.get(entity, []))
+    return _docstring_impl("includes", includes)
+
+def _docstring_search(entity):
+    search_fields = list(VALID_SEARCH_FIELDS.get(entity, []))
+    return _docstring_impl("fields", search_fields)
+
+def _docstring_impl(name, values):
     def _decorator(func):
-        if browse:
-            includes = list(VALID_BROWSE_INCLUDES.get(entity, []))
-        else:
-            includes = list(VALID_INCLUDES.get(entity, []))
         # puids are allowed so nothing breaks, but not documented
-        if "puids" in includes: includes.remove("puids")
-        includes = ", ".join(includes)
+        s = values
+        if "puids" in values: values.remove("puids")
+        vstr = ", ".join(values)
+        args = {name: vstr}
         if func.__doc__:
-            search_fields = list(VALID_SEARCH_FIELDS.get(entity, []))
-            # puid is allowed so nothing breaks, but not documented
-            if "puid" in search_fields: search_fields.remove("puid")
-            func.__doc__ = func.__doc__.format(includes=includes,
-                    fields=", ".join(search_fields))
+            func.__doc__ = func.__doc__.format(**args)
         return func
 
     return _decorator
@@ -782,7 +788,7 @@ def _do_mb_post(path, body):
 
 # Single entity by ID
 
-@_docstring('area')
+@_docstring_get("area")
 def get_area_by_id(id, includes=[], release_status=[], release_type=[]):
     """Get the area with the MusicBrainz `id` as a dict with an 'area' key.
 
@@ -791,7 +797,7 @@ def get_area_by_id(id, includes=[], release_status=[], release_type=[]):
                                            release_status, release_type)
     return _do_mb_query("area", id, includes, params)
 
-@_docstring('artist')
+@_docstring_get("artist")
 def get_artist_by_id(id, includes=[], release_status=[], release_type=[]):
     """Get the artist with the MusicBrainz `id` as a dict with an 'artist' key.
 
@@ -800,7 +806,7 @@ def get_artist_by_id(id, includes=[], release_status=[], release_type=[]):
                                            release_status, release_type)
     return _do_mb_query("artist", id, includes, params)
 
-@_docstring('instrument')
+@_docstring_get("instrument")
 def get_instrument_by_id(id, includes=[], release_status=[], release_type=[]):
     """Get the instrument with the MusicBrainz `id` as a dict with an 'artist' key.
 
@@ -809,7 +815,7 @@ def get_instrument_by_id(id, includes=[], release_status=[], release_type=[]):
                                            release_status, release_type)
     return _do_mb_query("instrument", id, includes, params)
 
-@_docstring('label')
+@_docstring_get("label")
 def get_label_by_id(id, includes=[], release_status=[], release_type=[]):
     """Get the label with the MusicBrainz `id` as a dict with a 'label' key.
 
@@ -818,7 +824,7 @@ def get_label_by_id(id, includes=[], release_status=[], release_type=[]):
                                            release_status, release_type)
     return _do_mb_query("label", id, includes, params)
 
-@_docstring('place')
+@_docstring_get("place")
 def get_place_by_id(id, includes=[], release_status=[], release_type=[]):
     """Get the place with the MusicBrainz `id` as a dict with an 'place' key.
 
@@ -827,7 +833,7 @@ def get_place_by_id(id, includes=[], release_status=[], release_type=[]):
                                            release_status, release_type)
     return _do_mb_query("place", id, includes, params)
 
-@_docstring('event')
+@_docstring_get("event")
 def get_event_by_id(id, includes=[], release_status=[], release_type=[]):
     """Get the event with the MusicBrainz `id` as a dict with an 'event' key.
 
@@ -839,7 +845,7 @@ def get_event_by_id(id, includes=[], release_status=[], release_type=[]):
                                            release_status, release_type)
     return _do_mb_query("event", id, includes, params)
 
-@_docstring('recording')
+@_docstring_get("recording")
 def get_recording_by_id(id, includes=[], release_status=[], release_type=[]):
     """Get the recording with the MusicBrainz `id` as a dict
     with a 'recording' key.
@@ -849,7 +855,7 @@ def get_recording_by_id(id, includes=[], release_status=[], release_type=[]):
                                            release_status, release_type)
     return _do_mb_query("recording", id, includes, params)
 
-@_docstring('release')
+@_docstring_get("release")
 def get_release_by_id(id, includes=[], release_status=[], release_type=[]):
     """Get the release with the MusicBrainz `id` as a dict with a 'release' key.
 
@@ -858,7 +864,7 @@ def get_release_by_id(id, includes=[], release_status=[], release_type=[]):
                                            release_status, release_type)
     return _do_mb_query("release", id, includes, params)
 
-@_docstring('release-group')
+@_docstring_get("release-group")
 def get_release_group_by_id(id, includes=[],
                             release_status=[], release_type=[]):
     """Get the release group with the MusicBrainz `id` as a dict
@@ -869,21 +875,21 @@ def get_release_group_by_id(id, includes=[],
                                            release_status, release_type)
     return _do_mb_query("release-group", id, includes, params)
 
-@_docstring('series')
+@_docstring_get("series")
 def get_series_by_id(id, includes=[]):
     """Get the series with the MusicBrainz `id` as a dict with a 'series' key.
 
     *Available includes*: {includes}"""
     return _do_mb_query("series", id, includes)
 
-@_docstring('work')
+@_docstring_get("work")
 def get_work_by_id(id, includes=[]):
     """Get the work with the MusicBrainz `id` as a dict with a 'work' key.
 
     *Available includes*: {includes}"""
     return _do_mb_query("work", id, includes)
 
-@_docstring('url')
+@_docstring_get("url")
 def get_url_by_id(id, includes=[]):
     """Get the url with the MusicBrainz `id` as a dict with a 'url' key.
 
@@ -893,49 +899,49 @@ def get_url_by_id(id, includes=[]):
 
 # Searching
 
-@_docstring('annotation')
+@_docstring_search("annotation")
 def search_annotations(query='', limit=None, offset=None, strict=False, **fields):
     """Search for annotations and return a dict with an 'annotation-list' key.
 
     *Available search fields*: {fields}"""
     return _do_mb_search('annotation', query, fields, limit, offset, strict)
 
-@_docstring('area')
+@_docstring_search("area")
 def search_areas(query='', limit=None, offset=None, strict=False, **fields):
     """Search for areas and return a dict with an 'area-list' key.
 
     *Available search fields*: {fields}"""
     return _do_mb_search('area', query, fields, limit, offset, strict)
 
-@_docstring('artist')
+@_docstring_search("artist")
 def search_artists(query='', limit=None, offset=None, strict=False, **fields):
     """Search for artists and return a dict with an 'artist-list' key.
 
     *Available search fields*: {fields}"""
     return _do_mb_search('artist', query, fields, limit, offset, strict)
 
-@_docstring('event')
+@_docstring_search("event")
 def search_events(query='', limit=None, offset=None, strict=False, **fields):
     """Search for events and return a dict with an 'event-list' key.
 
     *Available search fields*: {fields}"""
     return _do_mb_search('event', query, fields, limit, offset, strict)
 
-@_docstring('instrument')
+@_docstring_search("instrument")
 def search_instruments(query='', limit=None, offset=None, strict=False, **fields):
     """Search for instruments and return a dict with a 'instrument-list' key.
 
     *Available search fields*: {fields}"""
     return _do_mb_search('instrument', query, fields, limit, offset, strict)
 
-@_docstring('label')
+@_docstring_search("label")
 def search_labels(query='', limit=None, offset=None, strict=False, **fields):
     """Search for labels and return a dict with a 'label-list' key.
 
     *Available search fields*: {fields}"""
     return _do_mb_search('label', query, fields, limit, offset, strict)
 
-@_docstring('recording')
+@_docstring_search("recording")
 def search_recordings(query='', limit=None, offset=None,
                       strict=False, **fields):
     """Search for recordings and return a dict with a 'recording-list' key.
@@ -943,14 +949,14 @@ def search_recordings(query='', limit=None, offset=None,
     *Available search fields*: {fields}"""
     return _do_mb_search('recording', query, fields, limit, offset, strict)
 
-@_docstring('release')
+@_docstring_search("release")
 def search_releases(query='', limit=None, offset=None, strict=False, **fields):
     """Search for recordings and return a dict with a 'recording-list' key.
 
     *Available search fields*: {fields}"""
     return _do_mb_search('release', query, fields, limit, offset, strict)
 
-@_docstring('release-group')
+@_docstring_search("release-group")
 def search_release_groups(query='', limit=None, offset=None,
 			  strict=False, **fields):
     """Search for release groups and return a dict
@@ -959,14 +965,14 @@ def search_release_groups(query='', limit=None, offset=None,
     *Available search fields*: {fields}"""
     return _do_mb_search('release-group', query, fields, limit, offset, strict)
 
-@_docstring('series')
+@_docstring_search("series")
 def search_series(query='', limit=None, offset=None, strict=False, **fields):
     """Search for series and return a dict with a 'series-list' key.
 
     *Available search fields*: {fields}"""
     return _do_mb_search('series', query, fields, limit, offset, strict)
 
-@_docstring('work')
+@_docstring_search("work")
 def search_works(query='', limit=None, offset=None, strict=False, **fields):
     """Search for works and return a dict with a 'work-list' key.
 
@@ -975,7 +981,7 @@ def search_works(query='', limit=None, offset=None, strict=False, **fields):
 
 
 # Lists of entities
-@_docstring('discid')
+@_docstring_get("discid")
 def get_releases_by_discid(id, includes=[], toc=None, cdstubs=True, media_format=None):
     """Search for releases with a :musicbrainz:`Disc ID` or table of contents.
 
@@ -1010,7 +1016,7 @@ def get_releases_by_discid(id, includes=[], toc=None, cdstubs=True, media_format
         params["media-format"] = media_format
     return _do_mb_query("discid", id, includes, params)
 
-@_docstring('recording')
+@_docstring_get("recording")
 def get_recordings_by_echoprint(echoprint, includes=[], release_status=[],
                                 release_type=[]):
     """Search for recordings with an `echoprint <http://echoprint.me>`_.
@@ -1021,7 +1027,7 @@ def get_recordings_by_echoprint(echoprint, includes=[], release_status=[],
     raise ResponseError(cause=compat.HTTPError(
                                             None, 404, "Not Found", None, None))
 
-@_docstring('recording')
+@_docstring_get("recording")
 def get_recordings_by_puid(puid, includes=[], release_status=[],
                            release_type=[]):
     """Search for recordings with a :musicbrainz:`PUID`.
@@ -1032,7 +1038,7 @@ def get_recordings_by_puid(puid, includes=[], release_status=[],
     raise ResponseError(cause=compat.HTTPError(
                                             None, 404, "Not Found", None, None))
 
-@_docstring('recording')
+@_docstring_get("recording")
 def get_recordings_by_isrc(isrc, includes=[], release_status=[],
                            release_type=[]):
     """Search for recordings with an :musicbrainz:`ISRC`.
@@ -1044,7 +1050,7 @@ def get_recordings_by_isrc(isrc, includes=[], release_status=[],
                                            release_status, release_type)
     return _do_mb_query("isrc", isrc, includes, params)
 
-@_docstring('work')
+@_docstring_get("work")
 def get_works_by_iswc(iswc, includes=[]):
     """Search for works with an :musicbrainz:`ISWC`.
     The result is a dict with a`work-list`.
@@ -1071,7 +1077,7 @@ def _browse_impl(entity, includes, valid_includes, limit, offset, params, releas
 # Browse methods
 # Browse include are a subset of regular get includes, so we check them here
 # and the test in _do_mb_query will pass anyway.
-@_docstring('artists', browse=True)
+@_docstring_browse("artists")
 def browse_artists(recording=None, release=None, release_group=None,
                    includes=[], limit=None, offset=None):
     """Get all artists linked to a recording, a release or a release group.
@@ -1086,7 +1092,7 @@ def browse_artists(recording=None, release=None, release_group=None,
     return _browse_impl("artist", includes, valid_includes,
                         limit, offset, params)
 
-@_docstring('events', browse=True)
+@_docstring_browse("events")
 def browse_events(area=None, artist=None, place=None,
                    includes=[], limit=None, offset=None):
     """Get all events linked to a area, a artist or a place.
@@ -1100,7 +1106,7 @@ def browse_events(area=None, artist=None, place=None,
     return _browse_impl("event", includes, valid_includes,
                         limit, offset, params)
 
-@_docstring('labels', browse=True)
+@_docstring_browse("labels")
 def browse_labels(release=None, includes=[], limit=None, offset=None):
     """Get all labels linked to a relase. You need to give a MusicBrainz ID.
 
@@ -1110,7 +1116,7 @@ def browse_labels(release=None, includes=[], limit=None, offset=None):
     return _browse_impl("label", includes, valid_includes,
                         limit, offset, params)
 
-@_docstring('recordings', browse=True)
+@_docstring_browse("recordings")
 def browse_recordings(artist=None, release=None, includes=[],
                       limit=None, offset=None):
     """Get all recordings linked to an artist or a release.
@@ -1123,7 +1129,7 @@ def browse_recordings(artist=None, release=None, includes=[],
     return _browse_impl("recording", includes, valid_includes,
                         limit, offset, params)
 
-@_docstring('releases', browse=True)
+@_docstring_browse("releases")
 def browse_releases(artist=None, track_artist=None, label=None, recording=None,
                     release_group=None, release_status=[], release_type=[],
                     includes=[], limit=None, offset=None):
@@ -1147,7 +1153,7 @@ def browse_releases(artist=None, track_artist=None, label=None, recording=None,
     return _browse_impl("release", includes, valid_includes, limit, offset,
                         params, release_status, release_type)
 
-@_docstring('release-groups', browse=True)
+@_docstring_browse("release-groups")
 def browse_release_groups(artist=None, release=None, release_type=[],
                           includes=[], limit=None, offset=None):
     """Get all release groups linked to an artist or a release.
@@ -1162,7 +1168,7 @@ def browse_release_groups(artist=None, release=None, release_type=[],
     return _browse_impl("release-group", includes, valid_includes,
                         limit, offset, params, [], release_type)
 
-@_docstring('urls', browse=True)
+@_docstring_browse("urls")
 def browse_urls(resource=None, includes=[], limit=None, offset=None):
     """Get urls by actual URL string.
     You need to give a URL string as 'resource'

--- a/musicbrainzngs/musicbrainz.py
+++ b/musicbrainzngs/musicbrainz.py
@@ -83,14 +83,14 @@ VALID_INCLUDES = {
     'collection': ['releases'],
 }
 VALID_BROWSE_INCLUDES = {
-    'releases': ["artist-credits", "labels", "recordings", "isrcs",
+    'release': ["artist-credits", "labels", "recordings", "isrcs",
                 "release-groups", "media", "discids"] + RELATION_INCLUDES,
-    'recordings': ["artist-credits", "isrcs"] + TAG_INCLUDES + RATING_INCLUDES + RELATION_INCLUDES,
-    'labels': ["aliases"] + TAG_INCLUDES + RATING_INCLUDES + RELATION_INCLUDES,
-    'artists': ["aliases"] + TAG_INCLUDES + RATING_INCLUDES + RELATION_INCLUDES,
-    'events': ["aliases"] + TAG_INCLUDES + RATING_INCLUDES + RELATION_INCLUDES,
-    'urls': RELATION_INCLUDES,
-    'release-groups': ["artist-credits"] + TAG_INCLUDES + RATING_INCLUDES + RELATION_INCLUDES
+    'recording': ["artist-credits", "isrcs"] + TAG_INCLUDES + RATING_INCLUDES + RELATION_INCLUDES,
+    'label': ["aliases"] + TAG_INCLUDES + RATING_INCLUDES + RELATION_INCLUDES,
+    'artist': ["aliases"] + TAG_INCLUDES + RATING_INCLUDES + RELATION_INCLUDES,
+    'event': ["aliases"] + TAG_INCLUDES + RATING_INCLUDES + RELATION_INCLUDES,
+    'url': RELATION_INCLUDES,
+    'release-group': ["artist-credits"] + TAG_INCLUDES + RATING_INCLUDES + RELATION_INCLUDES
 }
 
 #: These can be used to filter whenever releases are includes or browsed
@@ -1059,8 +1059,9 @@ def get_works_by_iswc(iswc, includes=[]):
     return _do_mb_query("iswc", iswc, includes)
 
 
-def _browse_impl(entity, includes, valid_includes, limit, offset, params, release_status=[], release_type=[]):
+def _browse_impl(entity, includes, limit, offset, params, release_status=[], release_type=[]):
     includes = includes if isinstance(includes, list) else [includes]
+    valid_includes = VALID_BROWSE_INCLUDES[entity]
     _check_includes_impl(includes, valid_includes)
     p = {}
     for k,v in params.items():
@@ -1077,7 +1078,7 @@ def _browse_impl(entity, includes, valid_includes, limit, offset, params, releas
 # Browse methods
 # Browse include are a subset of regular get includes, so we check them here
 # and the test in _do_mb_query will pass anyway.
-@_docstring_browse("artists")
+@_docstring_browse("artist")
 def browse_artists(recording=None, release=None, release_group=None,
                    includes=[], limit=None, offset=None):
     """Get all artists linked to a recording, a release or a release group.
@@ -1085,51 +1086,43 @@ def browse_artists(recording=None, release=None, release_group=None,
 
     *Available includes*: {includes}"""
     # optional parameter work?
-    valid_includes = VALID_BROWSE_INCLUDES['artists']
     params = {"recording": recording,
               "release": release,
               "release-group": release_group}
-    return _browse_impl("artist", includes, valid_includes,
-                        limit, offset, params)
+    return _browse_impl("artist", includes, limit, offset, params)
 
-@_docstring_browse("events")
+@_docstring_browse("event")
 def browse_events(area=None, artist=None, place=None,
                    includes=[], limit=None, offset=None):
     """Get all events linked to a area, a artist or a place.
     You need to give one MusicBrainz ID.
 
     *Available includes*: {includes}"""
-    valid_includes = VALID_BROWSE_INCLUDES['events']
     params = {"area": area,
               "artist": artist,
               "place": place}
-    return _browse_impl("event", includes, valid_includes,
-                        limit, offset, params)
+    return _browse_impl("event", includes, limit, offset, params)
 
-@_docstring_browse("labels")
+@_docstring_browse("label")
 def browse_labels(release=None, includes=[], limit=None, offset=None):
     """Get all labels linked to a relase. You need to give a MusicBrainz ID.
 
     *Available includes*: {includes}"""
-    valid_includes = VALID_BROWSE_INCLUDES['labels']
     params = {"release": release}
-    return _browse_impl("label", includes, valid_includes,
-                        limit, offset, params)
+    return _browse_impl("label", includes, limit, offset, params)
 
-@_docstring_browse("recordings")
+@_docstring_browse("recording")
 def browse_recordings(artist=None, release=None, includes=[],
                       limit=None, offset=None):
     """Get all recordings linked to an artist or a release.
     You need to give one MusicBrainz ID.
 
     *Available includes*: {includes}"""
-    valid_includes = VALID_BROWSE_INCLUDES['recordings']
     params = {"artist": artist,
               "release": release}
-    return _browse_impl("recording", includes, valid_includes,
-                        limit, offset, params)
+    return _browse_impl("recording", includes, limit, offset, params)
 
-@_docstring_browse("releases")
+@_docstring_browse("release")
 def browse_releases(artist=None, track_artist=None, label=None, recording=None,
                     release_group=None, release_status=[], release_type=[],
                     includes=[], limit=None, offset=None):
@@ -1144,16 +1137,15 @@ def browse_releases(artist=None, track_artist=None, label=None, recording=None,
 
     *Available includes*: {includes}"""
     # track_artist param doesn't work yet
-    valid_includes = VALID_BROWSE_INCLUDES['releases']
     params = {"artist": artist,
               "track_artist": track_artist,
               "label": label,
               "recording": recording,
               "release-group": release_group}
-    return _browse_impl("release", includes, valid_includes, limit, offset,
+    return _browse_impl("release", includes, limit, offset,
                         params, release_status, release_type)
 
-@_docstring_browse("release-groups")
+@_docstring_browse("release-group")
 def browse_release_groups(artist=None, release=None, release_type=[],
                           includes=[], limit=None, offset=None):
     """Get all release groups linked to an artist or a release.
@@ -1162,25 +1154,19 @@ def browse_release_groups(artist=None, release=None, release_type=[],
     You can filter by :data:`musicbrainz.VALID_RELEASE_TYPES`.
 
     *Available includes*: {includes}"""
-    valid_includes = VALID_BROWSE_INCLUDES['release-groups']
     params = {"artist": artist,
               "release": release}
-    return _browse_impl("release-group", includes, valid_includes,
-                        limit, offset, params, [], release_type)
+    return _browse_impl("release-group", includes, limit,
+                        offset, params, [], release_type)
 
-@_docstring_browse("urls")
+@_docstring_browse("url")
 def browse_urls(resource=None, includes=[], limit=None, offset=None):
     """Get urls by actual URL string.
     You need to give a URL string as 'resource'
 
     *Available includes*: {includes}"""
-    # optional parameter work?
-    valid_includes = VALID_BROWSE_INCLUDES['urls']
     params = {"resource": resource}
-    return _browse_impl("url", includes, valid_includes,
-                        limit, offset, params)
-
-# browse_work is defined in the docs but has no browse criteria
+    return _browse_impl("url", includes, limit, offset, params)
 
 # Collections
 def get_collections():

--- a/test/test_browse.py
+++ b/test/test_browse.py
@@ -28,3 +28,105 @@ class BrowseTest(unittest.TestCase):
         musicbrainzngs.browse_events(area=area, includes="aliases")
         self.assertEqual("http://musicbrainz.org/ws/2/event/?area=74e50e58-5deb-4b99-93a2-decbb365c07f&inc=aliases", self.opener.get_url())
 
+    def test_browse_multiple_by(self):
+        """It is an error to choose multiple entities to browse by"""
+        with self.assertRaises(Exception):
+            musicbrainzngs.browse_artists(recording="1", release="2")
+
+    def test_browse_limit_offset(self):
+        """Limit and offset values"""
+        area = "74e50e58-5deb-4b99-93a2-decbb365c07f"
+        musicbrainzngs.browse_events(area=area, limit=50, offset=100)
+        self.assertEqual("http://musicbrainz.org/ws/2/event/?area=74e50e58-5deb-4b99-93a2-decbb365c07f&limit=50&offset=100", self.opener.get_url())
+        pass
+
+    def test_browse_artist(self):
+        release = "9ace7c8c-55b4-4c5d-9aa8-e573a5dde9ad"
+        musicbrainzngs.browse_artists(release=release)
+        self.assertEqual("http://musicbrainz.org/ws/2/artist/?release=9ace7c8c-55b4-4c5d-9aa8-e573a5dde9ad", self.opener.get_url())
+
+        recording = "6da2cc31-9b12-4b66-9e26-074150f73406"
+        musicbrainzngs.browse_artists(recording=recording)
+        self.assertEqual("http://musicbrainz.org/ws/2/artist/?recording=6da2cc31-9b12-4b66-9e26-074150f73406", self.opener.get_url())
+
+        release_group = "44c90c72-76b5-3c13-890e-3d37f21c10c9"
+        musicbrainzngs.browse_artists(release_group=release_group)
+        self.assertEqual("http://musicbrainz.org/ws/2/artist/?release-group=44c90c72-76b5-3c13-890e-3d37f21c10c9", self.opener.get_url())
+
+    def test_browse_event(self):
+        area = "f03d09b3-39dc-4083-afd6-159e3f0d462f"
+        musicbrainzngs.browse_events(area=area)
+        self.assertEqual("http://musicbrainz.org/ws/2/event/?area=f03d09b3-39dc-4083-afd6-159e3f0d462f", self.opener.get_url())
+
+        artist = "0383dadf-2a4e-4d10-a46a-e9e041da8eb3"
+        musicbrainzngs.browse_events(artist=artist)
+        self.assertEqual("http://musicbrainz.org/ws/2/event/?artist=0383dadf-2a4e-4d10-a46a-e9e041da8eb3", self.opener.get_url())
+
+        place = "8a6161bb-fb50-4234-82c5-1e24ab342499"
+        musicbrainzngs.browse_events(place=place)
+        self.assertEqual("http://musicbrainz.org/ws/2/event/?place=8a6161bb-fb50-4234-82c5-1e24ab342499", self.opener.get_url())
+
+    def test_browse_label(self):
+        release = "c9550260-b7ae-4670-ac24-731c19e76b59"
+        musicbrainzngs.browse_labels(release=release)
+        self.assertEqual("http://musicbrainz.org/ws/2/label/?release=c9550260-b7ae-4670-ac24-731c19e76b59", self.opener.get_url())
+
+    def test_browse_recording(self):
+        artist = "47f67b22-affe-4fe1-9d25-853d69bc0ee3"
+        musicbrainzngs.browse_recordings(artist=artist)
+        self.assertEqual("http://musicbrainz.org/ws/2/recording/?artist=47f67b22-affe-4fe1-9d25-853d69bc0ee3", self.opener.get_url())
+
+        release = "438042ef-7ccc-4d03-9391-4f66427b2055"
+        musicbrainzngs.browse_recordings(release=release)
+        self.assertEqual("http://musicbrainz.org/ws/2/recording/?release=438042ef-7ccc-4d03-9391-4f66427b2055", self.opener.get_url())
+
+    def test_browse_release(self):
+        artist = "47f67b22-affe-4fe1-9d25-853d69bc0ee3"
+        musicbrainzngs.browse_releases(artist=artist)
+        self.assertEqual("http://musicbrainz.org/ws/2/release/?artist=47f67b22-affe-4fe1-9d25-853d69bc0ee3", self.opener.get_url())
+        musicbrainzngs.browse_releases(track_artist=artist)
+        self.assertEqual("http://musicbrainz.org/ws/2/release/?track_artist=47f67b22-affe-4fe1-9d25-853d69bc0ee3", self.opener.get_url())
+
+        label = "713c4a95-6616-442b-9cf6-14e1ddfd5946"
+        musicbrainzngs.browse_releases(label=label)
+        self.assertEqual("http://musicbrainz.org/ws/2/release/?label=713c4a95-6616-442b-9cf6-14e1ddfd5946", self.opener.get_url())
+
+        recording = "7484fcfd-1968-4401-a44d-d1edcc580518"
+        musicbrainzngs.browse_releases(recording=recording)
+        self.assertEqual("http://musicbrainz.org/ws/2/release/?recording=7484fcfd-1968-4401-a44d-d1edcc580518", self.opener.get_url())
+
+        release_group = "1c1b54f7-e56a-3ce8-b62c-e45c378e7f76"
+        musicbrainzngs.browse_releases(release_group=release_group)
+        self.assertEqual("http://musicbrainz.org/ws/2/release/?release-group=1c1b54f7-e56a-3ce8-b62c-e45c378e7f76", self.opener.get_url())
+
+    def test_browse_release_group(self):
+        artist = "47f67b22-affe-4fe1-9d25-853d69bc0ee3"
+        musicbrainzngs.browse_release_groups(artist=artist)
+        self.assertEqual("http://musicbrainz.org/ws/2/release-group/?artist=47f67b22-affe-4fe1-9d25-853d69bc0ee3", self.opener.get_url())
+
+        release = "438042ef-7ccc-4d03-9391-4f66427b2055"
+        musicbrainzngs.browse_release_groups(release=release)
+        self.assertEqual("http://musicbrainz.org/ws/2/release-group/?release=438042ef-7ccc-4d03-9391-4f66427b2055", self.opener.get_url())
+
+        release = "438042ef-7ccc-4d03-9391-4f66427b2055"
+        rel_type = "ep"
+        musicbrainzngs.browse_release_groups(release=release, release_type=rel_type)
+        self.assertEqual("http://musicbrainz.org/ws/2/release-group/?release=438042ef-7ccc-4d03-9391-4f66427b2055&type=ep", self.opener.get_url())
+
+    def test_browse_url(self):
+        resource = "http://www.queenonline.com"
+        musicbrainzngs.browse_urls(resource=resource)
+        self.assertEqual("http://musicbrainz.org/ws/2/url/?resource=http%3A%2F%2Fwww.queenonline.com", self.opener.get_url())
+
+        # Resource is urlencoded, including ? and =
+        resource = "http://www.splendidezine.com/review.html?reviewid=1109588405202831"
+        musicbrainzngs.browse_urls(resource=resource)
+        self.assertEqual("http://musicbrainz.org/ws/2/url/?resource=http%3A%2F%2Fwww.splendidezine.com%2Freview.html%3Freviewid%3D1109588405202831", self.opener.get_url())
+
+    @unittest.skip("waiting for merge")
+    def test_browse_includes_is_subset_of_includes(self):
+        """Check that VALID_BROWSE_INCLUDES is a strict subset of
+           VALID_INCLUDES"""
+        for entity, includes in musicbrainzngs.VALID_BROWSE_INCLUDES.items():
+            for i in includes:
+                self.assertTrue(i in musicbrainzngs.VALID_INCLUDES[entity], "entity %s, %s in BROWSE_INCLUDES but not VALID_INCLUDES" % (entity, i))

--- a/test/test_browse.py
+++ b/test/test_browse.py
@@ -38,7 +38,6 @@ class BrowseTest(unittest.TestCase):
         area = "74e50e58-5deb-4b99-93a2-decbb365c07f"
         musicbrainzngs.browse_events(area=area, limit=50, offset=100)
         self.assertEqual("http://musicbrainz.org/ws/2/event/?area=74e50e58-5deb-4b99-93a2-decbb365c07f&limit=50&offset=100", self.opener.get_url())
-        pass
 
     def test_browse_artist(self):
         release = "9ace7c8c-55b4-4c5d-9aa8-e573a5dde9ad"
@@ -52,6 +51,10 @@ class BrowseTest(unittest.TestCase):
         release_group = "44c90c72-76b5-3c13-890e-3d37f21c10c9"
         musicbrainzngs.browse_artists(release_group=release_group)
         self.assertEqual("http://musicbrainz.org/ws/2/artist/?release-group=44c90c72-76b5-3c13-890e-3d37f21c10c9", self.opener.get_url())
+
+        work = "deb27b88-cf41-4f7c-b3aa-bc3268bc3c02"
+        musicbrainzngs.browse_artists(work=work)
+        self.assertEqual("http://musicbrainz.org/ws/2/artist/?work=deb27b88-cf41-4f7c-b3aa-bc3268bc3c02", self.opener.get_url())
 
     def test_browse_event(self):
         area = "f03d09b3-39dc-4083-afd6-159e3f0d462f"
@@ -79,6 +82,13 @@ class BrowseTest(unittest.TestCase):
         release = "438042ef-7ccc-4d03-9391-4f66427b2055"
         musicbrainzngs.browse_recordings(release=release)
         self.assertEqual("http://musicbrainz.org/ws/2/recording/?release=438042ef-7ccc-4d03-9391-4f66427b2055", self.opener.get_url())
+
+    @unittest.skip("missing browse implementation")
+    def test_browse_place(self):
+        area = "74e50e58-5deb-4b99-93a2-decbb365c07f"
+        musicbrainzngs.browse_places(area=area)
+        self.assertEqual("http://musicbrainz.org/ws/2/place/?area=74e50e58-5deb-4b99-93a2-decbb365c07f", self.opener.get_url())
+
 
     def test_browse_release(self):
         artist = "47f67b22-affe-4fe1-9d25-853d69bc0ee3"
@@ -122,6 +132,11 @@ class BrowseTest(unittest.TestCase):
         resource = "http://www.splendidezine.com/review.html?reviewid=1109588405202831"
         musicbrainzngs.browse_urls(resource=resource)
         self.assertEqual("http://musicbrainz.org/ws/2/url/?resource=http%3A%2F%2Fwww.splendidezine.com%2Freview.html%3Freviewid%3D1109588405202831", self.opener.get_url())
+
+    def test_browse_work(self):
+        artist = "0383dadf-2a4e-4d10-a46a-e9e041da8eb3"
+        musicbrainzngs.browse_works(artist=artist)
+        self.assertEqual("http://musicbrainz.org/ws/2/work/?artist=0383dadf-2a4e-4d10-a46a-e9e041da8eb3", self.opener.get_url())
 
     @unittest.skip("waiting for merge")
     def test_browse_includes_is_subset_of_includes(self):


### PR DESCRIPTION
Clean up some stuff around browsing. 

Diff is against https://github.com/alastair/python-musicbrainzngs/pull/188 because we need the new browse parameter support in the tests.

We now refer to `VALID_BROWSE_INCLUDES` with a singular of the entity so that we don't have to pass the valid includes into `_browse_impl`.
Documentation decorators have been cleaned up to remove hacky boolean flags.

I added tests for every browse method, finding some errors in musicbrainz along the way:
http://tickets.musicbrainz.org/browse/MBS-8757
http://tickets.musicbrainz.org/browse/MBS-8758
http://tickets.musicbrainz.org/browse/MBS-8759
http://tickets.musicbrainz.org/browse/MBS-8760

There is a test that will fail until https://github.com/alastair/python-musicbrainzngs/pull/187 is merged, so I used `@unittest.skip()`, though this doesn't exist of 2.6, so it'll fail anyway.

Still to be added are some new browse methods: artist by work, work by artist, place by area.