### PR TITLE
Parse track-count element from search medium-list element

### DIFF
--- a/musicbrainzngs/mbxml.py
+++ b/musicbrainzngs/mbxml.py
@@ -414,9 +414,9 @@ def parse_medium_list(ml):
         if tag == "ws2:medium":
             medium_list.append(parse_medium(m))
         elif tag == "ws2:track-count":
-            track_count = m.text
+            track_count = int(m.text)
     ret = {"medium-list": medium_list}
-    if track_count:
+    if track_count is not None:
         ret["medium-track-count"] = track_count
 
     return (True, ret)

--- a/test/test_mbxml_search.py
+++ b/test/test_mbxml_search.py
@@ -78,7 +78,7 @@ class SearchReleaseTest(unittest.TestCase):
         self.assertEqual("100", one["ext:score"])
 
         # search results have a medium-list/track-count element
-        self.assertEqual("4", one["medium-track-count"])
+        self.assertEqual(4, one["medium-track-count"])
         self.assertEqual(1, one["medium-count"])
         self.assertEqual("CD", one["medium-list"][0]["format"])
 

--- a/test/test_mbxml_search.py
+++ b/test/test_mbxml_search.py
@@ -77,6 +77,11 @@ class SearchReleaseTest(unittest.TestCase):
         one = res["release-list"][0]
         self.assertEqual("100", one["ext:score"])
 
+        # search results have a medium-list/track-count element
+        self.assertEqual("4", one["medium-track-count"])
+        self.assertEqual(1, one["medium-count"])
+        self.assertEqual("CD", one["medium-list"][0]["format"])
+
 class SearchReleaseGroupTest(unittest.TestCase):
     def testFields(self):
         fn = os.path.join(DATA_DIR, "search-release-group.xml")


### PR DESCRIPTION
In search results, we see
```
<medium-list>
  <track-count>n</track-count>
  <medium>...</medium>
</medium-list>
```
So we need to treat track-count separately and not like a
`<medium>` element. Fixes #194
