### PR TITLE
Requests reloaded

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,10 @@
 0.7dev:
+    * Use requests to make HTTP requests (Adrian Sampson & Wieland Hoffmann)
+
+      Note that this changes the exception types of the `cause` attribute of
+      musicbrainzngs.musicbrainz.WebServiceError and its subclasses to instances
+      of requests.exceptions.RequestException and its subclasses.
+
 
 0.6 (2016-04-11):
     * don't require authentication when getting public collections (#87)

--- a/musicbrainzngs/caa.py
+++ b/musicbrainzngs/caa.py
@@ -10,6 +10,7 @@ __all__ = [
     ]
 
 import json
+import requests
 
 from musicbrainzngs import compat
 from musicbrainzngs import musicbrainz
@@ -54,31 +55,23 @@ def _caa_request(mbid, imageid=None, size=None, entitytype="release"):
     ))
     musicbrainz._log.debug("GET request for %s" % (url, ))
 
-    # Set up HTTP request handler and URL opener.
-    httpHandler = compat.HTTPHandler(debuglevel=0)
-    handlers = [httpHandler]
-
-    opener = compat.build_opener(*handlers)
-
-    # Make request.
-    req = musicbrainz._MusicbrainzHttpRequest("GET", url, None)
-    # Useragent isn't needed for CAA, but we'll add it if it exists
+    headers = {}
     if musicbrainz._useragent != "":
-        req.add_header('User-Agent', musicbrainz._useragent)
+        headers['User-Agent'] = musicbrainz._useragent
         musicbrainz._log.debug("requesting with UA %s" % musicbrainz._useragent)
 
-    resp = musicbrainz._safe_read(opener, req, None)
+    # Make request.
+    req = requests.Request("GET", url, headers=headers)
+    # Useragent isn't needed for CAA, but we'll add it if it exists
 
-    # TODO: The content type declared by the CAA for JSON files is
-    # 'applicaiton/octet-stream'. This is not useful to detect whether the
-    # content is JSON, so default to decoding JSON if no imageid was supplied.
-    # http://tickets.musicbrainz.org/browse/CAA-75
+    resp = musicbrainz._safe_read(req)
+
     if imageid:
         # If we asked for an image, return the image
-        return resp
+        return resp.content
     else:
         # Otherwise it's json
-        return json.loads(resp)
+        return resp.json()
 
 
 def get_image_list(releaseid):

--- a/musicbrainzngs/compat.py
+++ b/musicbrainzngs/compat.py
@@ -39,12 +39,15 @@ is_py3 = (_ver[0] == 3)
 
 if is_py2:
 	from StringIO import StringIO
+	from urlparse import urlunparse
+	from urllib import urlencode
 
 	bytes = str
 	unicode = unicode
 	basestring = basestring
 elif is_py3:
 	from io import StringIO
+	from urllib.parse import urlunparse, urlencode
 
 	unicode = str
 	bytes = bytes

--- a/musicbrainzngs/compat.py
+++ b/musicbrainzngs/compat.py
@@ -39,23 +39,12 @@ is_py3 = (_ver[0] == 3)
 
 if is_py2:
 	from StringIO import StringIO
-	from urllib2 import HTTPPasswordMgr, HTTPDigestAuthHandler, Request,\
-						HTTPHandler, build_opener, HTTPError, URLError,\
-						build_opener
-	from httplib import BadStatusLine, HTTPException
-	from urlparse import urlunparse
-	from urllib import urlencode
 
 	bytes = str
 	unicode = unicode
 	basestring = basestring
 elif is_py3:
 	from io import StringIO
-	from urllib.request import HTTPPasswordMgr, HTTPDigestAuthHandler, Request,\
-								HTTPHandler, build_opener
-	from urllib.error import HTTPError, URLError
-	from http.client import HTTPException, BadStatusLine
-	from urllib.parse import urlunparse, urlencode
 
 	unicode = str
 	bytes = bytes

--- a/musicbrainzngs/musicbrainz.py
+++ b/musicbrainzngs/musicbrainz.py
@@ -471,20 +471,20 @@ def _safe_read(request):
     :param request:
     """
     # Make request (with retries).
-    session = requests.Session()
-    adapter = requests.adapters.HTTPAdapter(max_retries=8)
-    session.mount('http://', adapter)
-    session.mount('https://', adapter)
-    try:
-        resp = session.send(request.prepare(), allow_redirects=True)
-        resp.raise_for_status()
-        return resp
-    except requests.HTTPError as exc:
-        if exc.response.status_code == 401:
-                raise AuthenticationError(cause=exc)
-        raise ResponseError(cause=exc)
-    except requests.RequestException as exc:
-        raise NetworkError(cause=exc)
+    with requests.Session() as session:
+        adapter = requests.adapters.HTTPAdapter(max_retries=8)
+        session.mount('http://', adapter)
+        session.mount('https://', adapter)
+        try:
+                resp = session.send(request.prepare(), allow_redirects=True)
+                resp.raise_for_status()
+                return resp
+        except requests.HTTPError as exc:
+                if exc.response.status_code == 401:
+                        raise AuthenticationError(cause=exc)
+                raise ResponseError(cause=exc)
+        except requests.RequestException as exc:
+                raise NetworkError(cause=exc)
 
 @_rate_limit
 def _mb_request(path, method='GET', auth_required=AUTH_NO,

--- a/musicbrainzngs/musicbrainz.py
+++ b/musicbrainzngs/musicbrainz.py
@@ -509,8 +509,11 @@ def _mb_request(path, method='GET', auth_required=AUTH_NO,
     if client_required:
         args["client"] = _client
 
+    if ws_format != "xml":
+        args["fmt"] = ws_format
+
     headers = {
-            "User-Agent": _useragent
+        "User-Agent": _useragent
     }
 
     if body:

--- a/musicbrainzngs/musicbrainz.py
+++ b/musicbrainzngs/musicbrainz.py
@@ -520,6 +520,26 @@ def _mb_request(path, method='GET', auth_required=AUTH_NO,
         # will be sent (avoids HTTP 411 error).
         headers['Content-Length'] = 0
 
+    # Convert args from a dictionary to a list of tuples
+    # so that the ordering of elements is stable for easy
+    # testing (in this case we order alphabetically)
+    # Encode Unicode arguments using UTF-8.
+    newargs = []
+    for key, value in sorted(args.items()):
+        if isinstance(value, compat.unicode):
+            value = value.encode('utf8')
+        newargs.append((key, value))
+
+    # Construct the full URL for the request, including hostname and
+    # query string.
+    url = compat.urlunparse((
+        'http',
+        hostname,
+        '/ws/2/%s' % path,
+        '',
+        compat.urlencode(newargs),
+        ''
+    ))
     # Add credentials if required.
     add_auth = False
     if auth_required == AUTH_YES:
@@ -541,7 +561,7 @@ def _mb_request(path, method='GET', auth_required=AUTH_NO,
     req = requests.Request(
             method,
             'http://{0}/ws/2/{1}'.format(hostname, path),
-            params=args,
+            params=newargs,
             auth=auth_handler,
             headers=headers,
             data=body,

--- a/musicbrainzngs/musicbrainz.py
+++ b/musicbrainzngs/musicbrainz.py
@@ -534,7 +534,7 @@ def _mb_request(path, method='GET', auth_required=AUTH_NO,
         newargs.append((key, value))
 
     # Construct the full URL for the request, including hostname and
-    # query string.
+    # query string
     url = compat.urlunparse((
         'http',
         hostname,
@@ -546,14 +546,14 @@ def _mb_request(path, method='GET', auth_required=AUTH_NO,
     # Add credentials if required.
     add_auth = False
     if auth_required == AUTH_YES:
-        # _log.debug("Auth required for %s" % url)
+        _log.debug("Auth required for %s" % url)
         if not user:
             raise UsageError("authorization required; "
                              "use auth(user, pass) first")
         add_auth = True
 
     if auth_required == AUTH_IFSET and user:
-        # _log.debug("Using auth for %s because user and pass is set" % url)
+        _log.debug("Using auth for %s because user and pass is set" % url)
         add_auth = True
 
     if add_auth:
@@ -562,12 +562,11 @@ def _mb_request(path, method='GET', auth_required=AUTH_NO,
         auth_handler = None
 
     req = requests.Request(
-            method,
-            'http://{0}/ws/2/{1}'.format(hostname, path),
-            params=newargs,
-            auth=auth_handler,
-            headers=headers,
-            data=body,
+        method,
+        url,
+        auth=auth_handler,
+        headers=headers,
+        data=body,
     )
 
     resp = _safe_read(req)

--- a/musicbrainzngs/musicbrainz.py
+++ b/musicbrainzngs/musicbrainz.py
@@ -466,6 +466,26 @@ def set_format(fmt="xml"):
         raise ValueError("invalid format: %s" % fmt)
 
 
+def _safe_read(request):
+    """
+    :param request:
+    """
+    # Make request (with retries).
+    session = requests.Session()
+    adapter = requests.adapters.HTTPAdapter(max_retries=8)
+    session.mount('http://', adapter)
+    session.mount('https://', adapter)
+    try:
+        resp = session.send(request.prepare(), allow_redirects=True)
+        resp.raise_for_status()
+        return resp
+    except requests.HTTPError as exc:
+        if exc.response.status_code == 401:
+                raise AuthenticationError(cause=exc)
+        raise ResponseError(cause=exc)
+    except requests.RequestException as exc:
+        raise NetworkError(cause=exc)
+
 @_rate_limit
 def _mb_request(path, method='GET', auth_required=AUTH_NO,
                 client_required=False, args=None, data=None, body=None):
@@ -484,54 +504,52 @@ def _mb_request(path, method='GET', auth_required=AUTH_NO,
 
     if _useragent == "":
         raise UsageError("set a proper user-agent with "
-                        "set_useragent(\"application name\", \"application version\", \"contact info (preferably URL or email for your application)\")")
+                         "set_useragent(\"application name\", \"application version\", \"contact info (preferably URL or email for your application)\")")
 
     if client_required:
         args["client"] = _client
 
-    headers = {}
+    headers = {
+            "User-Agent": _useragent
+    }
+
     if body:
         headers['Content-Type'] = 'application/xml; charset=UTF-8'
     else:
         # Explicitly indicate zero content length if no request data
         # will be sent (avoids HTTP 411 error).
-        headers['Content-Length'] = '0'
+        headers['Content-Length'] = 0
+
+    # Add credentials if required.
+    add_auth = False
+    if auth_required == AUTH_YES:
+        # _log.debug("Auth required for %s" % url)
+        if not user:
+            raise UsageError("authorization required; "
+                             "use auth(user, pass) first")
+        add_auth = True
+
+    if auth_required == AUTH_IFSET and user:
+        # _log.debug("Using auth for %s because user and pass is set" % url)
+        add_auth = True
+
+    if add_auth:
+        auth_handler = HTTPDigestAuth(user, password)
+    else:
+        auth_handler = None
 
     req = requests.Request(
-         method,
-         'http://{0}/ws/2/{1}'.format(hostname, path),
-         params=args,
-         auth=HTTPDigestAuth(user, password) if auth_required else None,
-         headers=headers,
-         data=body,
+            method,
+            'http://{0}/ws/2/{1}'.format(hostname, path),
+            params=args,
+            auth=auth_handler,
+            headers=headers,
+            data=body,
     )
 
-    # Make request (with retries).
-    session = requests.Session()
-    adapter = requests.adapters.HTTPAdapter(max_retries=8)
-    session.mount('http://', adapter)
-    session.mount('https://', adapter)
-    try:
-        resp = session.send(req.prepare(), allow_redirects=True)
-    except requests.RequestException as exc:
-        raise NetworkError(cause=exc)
-    if resp.status_code != 200:
-        raise ResponseError(
-                'API responded with code {0}'.format(resp.status_code)
-        )
+    resp = _safe_read(req)
 
-    # Parse the response.
-    try:
-        return mbxml.parse_message(resp.content)
-    except UnicodeError as exc:
-        raise ResponseError(cause=exc)
-    except Exception as exc:
-        if isinstance(exc, ETREE_EXCEPTIONS):
-            raise ResponseError(cause=exc)
-        else:
-            raise
-
-    return parser_fun(resp)
+    return parser_fun(resp.content)
 
 def _get_auth_type(entity, id, includes):
     """ Some calls require authentication. This returns

--- a/musicbrainzngs/musicbrainz.py
+++ b/musicbrainzngs/musicbrainz.py
@@ -7,14 +7,10 @@ import re
 import threading
 import time
 import logging
-import socket
-import hashlib
-import locale
-import sys
-import json
 import xml.etree.ElementTree as etree
 from xml.parsers import expat
-from warnings import warn
+import requests
+from requests.auth import HTTPDigestAuth
 
 from musicbrainzngs import mbxml
 from musicbrainzngs import util
@@ -399,125 +395,8 @@ class _rate_limit(object):
                 self.remaining_requests -= 1.0
             return self.fun(*args, **kwargs)
 
-# From pymb2
-class _RedirectPasswordMgr(compat.HTTPPasswordMgr):
-	def __init__(self):
-		self._realms = { }
-
-	def find_user_password(self, realm, uri):
-		# ignoring the uri parameter intentionally
-		try:
-			return self._realms[realm]
-		except KeyError:
-			return (None, None)
-
-	def add_password(self, realm, uri, username, password):
-		# ignoring the uri parameter intentionally
-		self._realms[realm] = (username, password)
-
-class _DigestAuthHandler(compat.HTTPDigestAuthHandler):
-    def get_authorization (self, req, chal):
-        qop = chal.get ('qop', None)
-        if qop and ',' in qop and 'auth' in qop.split (','):
-            chal['qop'] = 'auth'
-
-        return compat.HTTPDigestAuthHandler.get_authorization (self, req, chal)
-
-    def _encode_utf8(self, msg):
-        """The MusicBrainz server also accepts UTF-8 encoded passwords."""
-        encoding = sys.stdin.encoding or locale.getpreferredencoding()
-        try:
-            # This works on Python 2 (msg in bytes)
-            msg = msg.decode(encoding)
-        except AttributeError:
-            # on Python 3 (msg is already in unicode)
-            pass
-        return msg.encode("utf-8")
-
-    def get_algorithm_impls(self, algorithm):
-        # algorithm should be case-insensitive according to RFC2617
-        algorithm = algorithm.upper()
-        # lambdas assume digest modules are imported at the top level
-        if algorithm == 'MD5':
-            H = lambda x: hashlib.md5(self._encode_utf8(x)).hexdigest()
-        elif algorithm == 'SHA':
-            H = lambda x: hashlib.sha1(self._encode_utf8(x)).hexdigest()
-        # XXX MD5-sess
-        KD = lambda s, d: H("%s:%s" % (s, d))
-        return H, KD
-
-class _MusicbrainzHttpRequest(compat.Request):
-	""" A custom request handler that allows DELETE and PUT"""
-	def __init__(self, method, url, data=None):
-		compat.Request.__init__(self, url, data)
-		allowed_m = ["GET", "POST", "DELETE", "PUT"]
-		if method not in allowed_m:
-			raise ValueError("invalid method: %s" % method)
-		self.method = method
-
-	def get_method(self):
-		return self.method
-
 
 # Core (internal) functions for calling the MB API.
-
-def _safe_read(opener, req, body=None, max_retries=8, retry_delay_delta=2.0):
-	"""Open an HTTP request with a given URL opener and (optionally) a
-	request body. Transient errors lead to retries.  Permanent errors
-	and repeated errors are translated into a small set of handleable
-	exceptions. Return a bytestring.
-	"""
-	last_exc = None
-	for retry_num in range(max_retries):
-		if retry_num: # Not the first try: delay an increasing amount.
-			_log.info("retrying after delay (#%i)" % retry_num)
-			time.sleep(retry_num * retry_delay_delta)
-
-		try:
-			if body:
-				f = opener.open(req, body)
-			else:
-				f = opener.open(req)
-			return f.read()
-
-		except compat.HTTPError as exc:
-			if exc.code in (400, 404, 411):
-				# Bad request, not found, etc.
-				raise ResponseError(cause=exc)
-			elif exc.code in (503, 502, 500):
-				# Rate limiting, internal overloading...
-				_log.info("HTTP error %i" % exc.code)
-			elif exc.code in (401, ):
-				raise AuthenticationError(cause=exc)
-			else:
-				# Other, unknown error. Should handle more cases, but
-				# retrying for now.
-				_log.info("unknown HTTP error %i" % exc.code)
-			last_exc = exc
-		except compat.BadStatusLine as exc:
-			_log.info("bad status line")
-			last_exc = exc
-		except compat.HTTPException as exc:
-			_log.info("miscellaneous HTTP exception: %s" % str(exc))
-			last_exc = exc
-		except compat.URLError as exc:
-			if isinstance(exc.reason, socket.error):
-				code = exc.reason.errno
-				if code == 104: # "Connection reset by peer."
-					continue
-			raise NetworkError(cause=exc)
-		except socket.timeout as exc:
-			_log.info("socket timeout")
-			last_exc = exc
-		except socket.error as exc:
-			if exc.errno == 104:
-				continue
-			raise NetworkError(cause=exc)
-		except IOError as exc:
-			raise NetworkError(cause=exc)
-
-	# Out of retries!
-	raise NetworkError("retried %i times" % max_retries, last_exc)
 
 # Get the XML parsing exceptions to catch. The behavior chnaged with Python 2.7
 # and ElementTree 1.3.
@@ -605,72 +484,52 @@ def _mb_request(path, method='GET', auth_required=AUTH_NO,
 
     if _useragent == "":
         raise UsageError("set a proper user-agent with "
-                         "set_useragent(\"application name\", \"application version\", \"contact info (preferably URL or email for your application)\")")
+                        "set_useragent(\"application name\", \"application version\", \"contact info (preferably URL or email for your application)\")")
 
     if client_required:
         args["client"] = _client
 
-    if ws_format != "xml":
-        args["fmt"] = ws_format
-
-    # Convert args from a dictionary to a list of tuples
-    # so that the ordering of elements is stable for easy
-    # testing (in this case we order alphabetically)
-    # Encode Unicode arguments using UTF-8.
-    newargs = []
-    for key, value in sorted(args.items()):
-        if isinstance(value, compat.unicode):
-            value = value.encode('utf8')
-        newargs.append((key, value))
-
-    # Construct the full URL for the request, including hostname and
-    # query string.
-    url = compat.urlunparse((
-        'http',
-        hostname,
-        '/ws/2/%s' % path,
-        '',
-        compat.urlencode(newargs),
-        ''
-    ))
-    _log.debug("%s request for %s" % (method, url))
-
-    # Set up HTTP request handler and URL opener.
-    httpHandler = compat.HTTPHandler(debuglevel=0)
-    handlers = [httpHandler]
-
-    # Add credentials if required.
-    add_auth = False
-    if auth_required == AUTH_YES:
-        _log.debug("Auth required for %s" % url)
-        if not user:
-            raise UsageError("authorization required; "
-                             "use auth(user, pass) first")
-        add_auth = True
-
-    if auth_required == AUTH_IFSET and user:
-        _log.debug("Using auth for %s because user and pass is set" % url)
-        add_auth = True
-
-    if add_auth:
-        passwordMgr = _RedirectPasswordMgr()
-        authHandler = _DigestAuthHandler(passwordMgr)
-        authHandler.add_password("musicbrainz.org", (), user, password)
-        handlers.append(authHandler)
-
-    opener = compat.build_opener(*handlers)
-
-    # Make request.
-    req = _MusicbrainzHttpRequest(method, url, data)
-    req.add_header('User-Agent', _useragent)
-    _log.debug("requesting with UA %s" % _useragent)
+    headers = {}
     if body:
-        req.add_header('Content-Type', 'application/xml; charset=UTF-8')
-    elif not data and not req.has_header('Content-Length'):
+        headers['Content-Type'] = 'application/xml; charset=UTF-8'
+    else:
         # Explicitly indicate zero content length if no request data
         # will be sent (avoids HTTP 411 error).
-        req.add_header('Content-Length', '0')
-    resp = _safe_read(opener, req, body)
+        headers['Content-Length'] = '0'
+
+    req = requests.Request(
+         method,
+         'http://{0}/ws/2/{1}'.format(hostname, path),
+         params=args,
+         auth=HTTPDigestAuth(user, password) if auth_required else None,
+         headers=headers,
+         data=body,
+    )
+
+    # Make request (with retries).
+    session = requests.Session()
+    adapter = requests.adapters.HTTPAdapter(max_retries=8)
+    session.mount('http://', adapter)
+    session.mount('https://', adapter)
+    try:
+        resp = session.send(req.prepare(), allow_redirects=True)
+    except requests.RequestException as exc:
+        raise NetworkError(cause=exc)
+    if resp.status_code != 200:
+        raise ResponseError(
+                'API responded with code {0}'.format(resp.status_code)
+        )
+
+    # Parse the response.
+    try:
+        return mbxml.parse_message(resp.content)
+    except UnicodeError as exc:
+        raise ResponseError(cause=exc)
+    except Exception as exc:
+        if isinstance(exc, ETREE_EXCEPTIONS):
+            raise ResponseError(cause=exc)
+        else:
+            raise
 
     return parser_fun(resp)
 
@@ -711,7 +570,7 @@ def _do_mb_query(entity, id, includes=[], params={}):
 	return _mb_request(path, 'GET', auth_required, args=args)
 
 def _do_mb_search(entity, query='', fields={},
-		  limit=None, offset=None, strict=False):
+          limit=None, offset=None, strict=False):
 	"""Perform a full-text search on the MusicBrainz search server.
 	`query` is a lucene query string when no fields are set,
 	but is escaped when any fields are given. `fields` is a dictionary
@@ -724,7 +583,7 @@ def _do_mb_search(entity, query='', fields={},
 		clean_query = util._unicode(query)
 		if fields:
 			clean_query = re.sub(LUCENE_SPECIAL, r'\\\1',
-					     clean_query)
+                         clean_query)
 			if strict:
 				query_parts.append('"%s"' % clean_query)
 			else:
@@ -739,8 +598,8 @@ def _do_mb_search(entity, query='', fields={},
 			)
 		elif key == "puid":
 			warn("PUID support was removed from server\n"
-			     "the 'puid' field is ignored",
-			     Warning, stacklevel=2)
+                 "the 'puid' field is ignored",
+                 Warning, stacklevel=2)
 
 		# Escape Lucene's special characters.
 		value = util._unicode(value)
@@ -966,7 +825,7 @@ def search_releases(query='', limit=None, offset=None, strict=False, **fields):
 
 @_docstring_search("release-group")
 def search_release_groups(query='', limit=None, offset=None,
-			  strict=False, **fields):
+              strict=False, **fields):
     """Search for release groups and return a dict
     with a 'release-group-list' key.
 

--- a/musicbrainzngs/musicbrainz.py
+++ b/musicbrainzngs/musicbrainz.py
@@ -12,12 +12,20 @@ from xml.parsers import expat
 import requests
 from requests.auth import HTTPDigestAuth
 
+# Don't import Retry from urllib3 directly, this only works correctly the Retry
+# class form the urllib3 package requests vendors in is used.
+from requests.packages.urllib3.util.retry import Retry
+
 from musicbrainzngs import mbxml
 from musicbrainzngs import util
 from musicbrainzngs import compat
 
 _version = "0.7dev"
 _log = logging.getLogger("musicbrainzngs")
+
+_retry = Retry(total=8,
+               status_forcelist=[500, 502, 503],
+               backoff_factor=0.1)
 
 LUCENE_SPECIAL = r'([+\-&|!(){}\[\]\^"~*?:\\\/])'
 
@@ -472,7 +480,7 @@ def _safe_read(request):
     """
     # Make request (with retries).
     with requests.Session() as session:
-        adapter = requests.adapters.HTTPAdapter(max_retries=8)
+        adapter = requests.adapters.HTTPAdapter(max_retries=_retry)
         session.mount('http://', adapter)
         session.mount('https://', adapter)
         try:
@@ -483,6 +491,8 @@ def _safe_read(request):
                 if exc.response.status_code == 401:
                         raise AuthenticationError(cause=exc)
                 raise ResponseError(cause=exc)
+        except requests.RetryError as exc:
+                raise NetworkError(cause=exc)
         except requests.RequestException as exc:
                 raise NetworkError(cause=exc)
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
-from distutils.core import Command
+from setuptools import setup
+from setuptools import Command
 
 from musicbrainzngs import musicbrainz
 
@@ -53,6 +53,9 @@ setup(
     url="https://python-musicbrainzngs.readthedocs.org/",
     packages=['musicbrainzngs'],
     cmdclass={'test': test },
+    install_requires=[
+        'requests>=1.2.1'
+    ],
     license='BSD 2-clause',
     classifiers=[
         "Development Status :: 5 - Production/Stable",

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     packages=['musicbrainzngs'],
     cmdclass={'test': test },
     install_requires=[
-        'requests>=2.1.0'
+        'requests>=2.5.0'
     ],
     tests_require=[
         'requests-mock'

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     packages=['musicbrainzngs'],
     cmdclass={'test': test },
     install_requires=[
-        'requests>=1.2.1'
+        'requests>=2.1.0'
     ],
     tests_require=[
         'requests-mock'

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,9 @@ setup(
     install_requires=[
         'requests>=1.2.1'
     ],
+    tests_require=[
+        'requests-mock'
+    ],
     license='BSD 2-clause',
     classifiers=[
         "Development Status :: 5 - Production/Stable",
@@ -68,4 +71,3 @@ setup(
         "Topic :: Software Development :: Libraries :: Python Modules"
     ]
 )
-

--- a/test/_common.py
+++ b/test/_common.py
@@ -17,6 +17,12 @@ class RequestsMockingTestCase(TestCase):
         self.m = requests_mock.Mocker()
         self.m.start()
 
+    @property
+    def last_url(self):
+        """The last URL seen by the Mocker.
+        """
+        return self.m.request_history.pop().url
+
     def tearDown(self):
         self.m.stop()
 

--- a/test/_common.py
+++ b/test/_common.py
@@ -1,38 +1,24 @@
 """Common support for the test cases."""
+import requests_mock
 import time
-
 import musicbrainzngs
+
+
 from os.path import join
+from unittest import TestCase
 
-try:
-    from urllib2 import OpenerDirector
-except ImportError:
-    from urllib.request import OpenerDirector
-try:
-    import StringIO
-except ImportError:
-    import io as StringIO
 
-class FakeOpener(OpenerDirector):
-    """ A URL Opener that saves the URL requested and
-    returns a dummy response or raises an exception """
-    def __init__(self, response="<response/>", exception=None):
-        self.myurl = None
-        self.headers = None
-        self.response = response
-        self.exception = exception
+class RequestsMockingTestCase(TestCase):
+    """Mocks requests HTTP layer by instantiating a requests_mock.Mocker in setUp
+    and stopping it in tearDown. That object is available in the `m` attribute.
 
-    def open(self, request, body=None):
-        self.myurl = request.get_full_url()
-        self.headers = request.header_items()
-        self.request = request
-        if self.exception:
-            raise self.exception
-        else:
-            return StringIO.StringIO(self.response)
+    """
+    def setUp(self):
+        self.m = requests_mock.Mocker()
+        self.m.start()
 
-    def get_url(self):
-        return self.myurl
+    def tearDown(self):
+        self.m.stop()
 
 
 # Mock timing.
@@ -60,6 +46,7 @@ class Timecop(object):
     def restore(self):
         time.time = self.orig['time']
         time.sleep = self.orig['sleep']
+
 
 def open_and_parse_test_data(datadir, filename):
     """ Opens an XML file dumped from the MusicBrainz web service and returns

--- a/test/test_browse.py
+++ b/test/test_browse.py
@@ -6,30 +6,35 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 import musicbrainzngs
 from musicbrainzngs import musicbrainz
 from test import _common
+from re import compile
 
-class BrowseTest(unittest.TestCase):
 
+class BrowseTest(_common.RequestsMockingTestCase):
     def setUp(self):
-        self.opener = _common.FakeOpener("<response/>")
-        musicbrainzngs.compat.build_opener = lambda *args: self.opener
+        super(BrowseTest, self).setUp()
 
         musicbrainzngs.set_useragent("a", "1")
         musicbrainzngs.set_rate_limit(False)
 
+        self.m.get(compile("ws/2/.*/\?.*"), text="<response/>")
+
     def test_browse(self):
         area = "74e50e58-5deb-4b99-93a2-decbb365c07f"
         musicbrainzngs.browse_events(area=area)
-        self.assertEqual("http://musicbrainz.org/ws/2/event/?area=74e50e58-5deb-4b99-93a2-decbb365c07f", self.opener.get_url())
+        self.assertEqual("http://musicbrainz.org/ws/2/event/?area=74e50e58-5deb-4b99-93a2-decbb365c07f",
+                         self.m.request_history.pop().url)
 
     def test_browse_includes(self):
         area = "74e50e58-5deb-4b99-93a2-decbb365c07f"
         musicbrainzngs.browse_events(area=area, includes=["aliases", "area-rels"])
-        self.assertEqual("http://musicbrainz.org/ws/2/event/?area=74e50e58-5deb-4b99-93a2-decbb365c07f&inc=aliases+area-rels", self.opener.get_url())
+        self.assertEqual("http://musicbrainz.org/ws/2/event/?area=74e50e58-5deb-4b99-93a2-decbb365c07f&inc=aliases+area-rels",
+                         self.m.request_history.pop().url)
 
     def test_browse_single_include(self):
         area = "74e50e58-5deb-4b99-93a2-decbb365c07f"
         musicbrainzngs.browse_events(area=area, includes="aliases")
-        self.assertEqual("http://musicbrainz.org/ws/2/event/?area=74e50e58-5deb-4b99-93a2-decbb365c07f&inc=aliases", self.opener.get_url())
+        self.assertEqual("http://musicbrainz.org/ws/2/event/?area=74e50e58-5deb-4b99-93a2-decbb365c07f&inc=aliases",
+                         self.m.request_history.pop().url)
 
     def test_browse_multiple_by(self):
         """It is an error to choose multiple entities to browse by"""
@@ -40,105 +45,129 @@ class BrowseTest(unittest.TestCase):
         """Limit and offset values"""
         area = "74e50e58-5deb-4b99-93a2-decbb365c07f"
         musicbrainzngs.browse_events(area=area, limit=50, offset=100)
-        self.assertEqual("http://musicbrainz.org/ws/2/event/?area=74e50e58-5deb-4b99-93a2-decbb365c07f&limit=50&offset=100", self.opener.get_url())
+        # TODO: I had to switch the order of query arguments here
+        self.assertEqual("http://musicbrainz.org/ws/2/event/?offset=100&limit=50&area=74e50e58-5deb-4b99-93a2-decbb365c07f",
+                         self.m.request_history.pop().url)
 
     def test_browse_artist(self):
         release = "9ace7c8c-55b4-4c5d-9aa8-e573a5dde9ad"
         musicbrainzngs.browse_artists(release=release)
-        self.assertEqual("http://musicbrainz.org/ws/2/artist/?release=9ace7c8c-55b4-4c5d-9aa8-e573a5dde9ad", self.opener.get_url())
+        self.assertEqual("http://musicbrainz.org/ws/2/artist/?release=9ace7c8c-55b4-4c5d-9aa8-e573a5dde9ad",
+                         self.m.request_history.pop().url)
 
         recording = "6da2cc31-9b12-4b66-9e26-074150f73406"
         musicbrainzngs.browse_artists(recording=recording)
-        self.assertEqual("http://musicbrainz.org/ws/2/artist/?recording=6da2cc31-9b12-4b66-9e26-074150f73406", self.opener.get_url())
+        self.assertEqual("http://musicbrainz.org/ws/2/artist/?recording=6da2cc31-9b12-4b66-9e26-074150f73406",
+                         self.m.request_history.pop().url)
 
         release_group = "44c90c72-76b5-3c13-890e-3d37f21c10c9"
         musicbrainzngs.browse_artists(release_group=release_group)
-        self.assertEqual("http://musicbrainz.org/ws/2/artist/?release-group=44c90c72-76b5-3c13-890e-3d37f21c10c9", self.opener.get_url())
+        self.assertEqual("http://musicbrainz.org/ws/2/artist/?release-group=44c90c72-76b5-3c13-890e-3d37f21c10c9",
+                         self.m.request_history.pop().url)
 
         work = "deb27b88-cf41-4f7c-b3aa-bc3268bc3c02"
         musicbrainzngs.browse_artists(work=work)
-        self.assertEqual("http://musicbrainz.org/ws/2/artist/?work=deb27b88-cf41-4f7c-b3aa-bc3268bc3c02", self.opener.get_url())
+        self.assertEqual("http://musicbrainz.org/ws/2/artist/?work=deb27b88-cf41-4f7c-b3aa-bc3268bc3c02",
+                         self.m.request_history.pop().url)
 
     def test_browse_event(self):
         area = "f03d09b3-39dc-4083-afd6-159e3f0d462f"
         musicbrainzngs.browse_events(area=area)
-        self.assertEqual("http://musicbrainz.org/ws/2/event/?area=f03d09b3-39dc-4083-afd6-159e3f0d462f", self.opener.get_url())
+        self.assertEqual("http://musicbrainz.org/ws/2/event/?area=f03d09b3-39dc-4083-afd6-159e3f0d462f",
+                         self.m.request_history.pop().url)
 
         artist = "0383dadf-2a4e-4d10-a46a-e9e041da8eb3"
         musicbrainzngs.browse_events(artist=artist)
-        self.assertEqual("http://musicbrainz.org/ws/2/event/?artist=0383dadf-2a4e-4d10-a46a-e9e041da8eb3", self.opener.get_url())
+        self.assertEqual("http://musicbrainz.org/ws/2/event/?artist=0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                         self.m.request_history.pop().url)
 
         place = "8a6161bb-fb50-4234-82c5-1e24ab342499"
         musicbrainzngs.browse_events(place=place)
-        self.assertEqual("http://musicbrainz.org/ws/2/event/?place=8a6161bb-fb50-4234-82c5-1e24ab342499", self.opener.get_url())
+        self.assertEqual("http://musicbrainz.org/ws/2/event/?place=8a6161bb-fb50-4234-82c5-1e24ab342499",
+                         self.m.request_history.pop().url)
 
     def test_browse_label(self):
         release = "c9550260-b7ae-4670-ac24-731c19e76b59"
         musicbrainzngs.browse_labels(release=release)
-        self.assertEqual("http://musicbrainz.org/ws/2/label/?release=c9550260-b7ae-4670-ac24-731c19e76b59", self.opener.get_url())
+        self.assertEqual("http://musicbrainz.org/ws/2/label/?release=c9550260-b7ae-4670-ac24-731c19e76b59",
+                         self.m.request_history.pop().url)
 
     def test_browse_recording(self):
         artist = "47f67b22-affe-4fe1-9d25-853d69bc0ee3"
         musicbrainzngs.browse_recordings(artist=artist)
-        self.assertEqual("http://musicbrainz.org/ws/2/recording/?artist=47f67b22-affe-4fe1-9d25-853d69bc0ee3", self.opener.get_url())
+        self.assertEqual("http://musicbrainz.org/ws/2/recording/?artist=47f67b22-affe-4fe1-9d25-853d69bc0ee3",
+                         self.m.request_history.pop().url)
 
         release = "438042ef-7ccc-4d03-9391-4f66427b2055"
         musicbrainzngs.browse_recordings(release=release)
-        self.assertEqual("http://musicbrainz.org/ws/2/recording/?release=438042ef-7ccc-4d03-9391-4f66427b2055", self.opener.get_url())
+        self.assertEqual("http://musicbrainz.org/ws/2/recording/?release=438042ef-7ccc-4d03-9391-4f66427b2055",
+                         self.m.request_history.pop().url)
 
     def test_browse_place(self):
         area = "74e50e58-5deb-4b99-93a2-decbb365c07f"
         musicbrainzngs.browse_places(area=area)
-        self.assertEqual("http://musicbrainz.org/ws/2/place/?area=74e50e58-5deb-4b99-93a2-decbb365c07f", self.opener.get_url())
+        self.assertEqual("http://musicbrainz.org/ws/2/place/?area=74e50e58-5deb-4b99-93a2-decbb365c07f",
+                         self.m.request_history.pop().url)
 
 
     def test_browse_release(self):
         artist = "47f67b22-affe-4fe1-9d25-853d69bc0ee3"
         musicbrainzngs.browse_releases(artist=artist)
-        self.assertEqual("http://musicbrainz.org/ws/2/release/?artist=47f67b22-affe-4fe1-9d25-853d69bc0ee3", self.opener.get_url())
+        self.assertEqual("http://musicbrainz.org/ws/2/release/?artist=47f67b22-affe-4fe1-9d25-853d69bc0ee3",
+                         self.m.request_history.pop().url)
         musicbrainzngs.browse_releases(track_artist=artist)
-        self.assertEqual("http://musicbrainz.org/ws/2/release/?track_artist=47f67b22-affe-4fe1-9d25-853d69bc0ee3", self.opener.get_url())
+        self.assertEqual("http://musicbrainz.org/ws/2/release/?track_artist=47f67b22-affe-4fe1-9d25-853d69bc0ee3",
+                         self.m.request_history.pop().url)
 
         label = "713c4a95-6616-442b-9cf6-14e1ddfd5946"
         musicbrainzngs.browse_releases(label=label)
-        self.assertEqual("http://musicbrainz.org/ws/2/release/?label=713c4a95-6616-442b-9cf6-14e1ddfd5946", self.opener.get_url())
+        self.assertEqual("http://musicbrainz.org/ws/2/release/?label=713c4a95-6616-442b-9cf6-14e1ddfd5946",
+                         self.m.request_history.pop().url)
 
         recording = "7484fcfd-1968-4401-a44d-d1edcc580518"
         musicbrainzngs.browse_releases(recording=recording)
-        self.assertEqual("http://musicbrainz.org/ws/2/release/?recording=7484fcfd-1968-4401-a44d-d1edcc580518", self.opener.get_url())
+        self.assertEqual("http://musicbrainz.org/ws/2/release/?recording=7484fcfd-1968-4401-a44d-d1edcc580518",
+                         self.m.request_history.pop().url)
 
         release_group = "1c1b54f7-e56a-3ce8-b62c-e45c378e7f76"
         musicbrainzngs.browse_releases(release_group=release_group)
-        self.assertEqual("http://musicbrainz.org/ws/2/release/?release-group=1c1b54f7-e56a-3ce8-b62c-e45c378e7f76", self.opener.get_url())
+        self.assertEqual("http://musicbrainz.org/ws/2/release/?release-group=1c1b54f7-e56a-3ce8-b62c-e45c378e7f76",
+                         self.m.request_history.pop().url)
 
     def test_browse_release_group(self):
         artist = "47f67b22-affe-4fe1-9d25-853d69bc0ee3"
         musicbrainzngs.browse_release_groups(artist=artist)
-        self.assertEqual("http://musicbrainz.org/ws/2/release-group/?artist=47f67b22-affe-4fe1-9d25-853d69bc0ee3", self.opener.get_url())
+        self.assertEqual("http://musicbrainz.org/ws/2/release-group/?artist=47f67b22-affe-4fe1-9d25-853d69bc0ee3",
+                         self.m.request_history.pop().url)
 
         release = "438042ef-7ccc-4d03-9391-4f66427b2055"
         musicbrainzngs.browse_release_groups(release=release)
-        self.assertEqual("http://musicbrainz.org/ws/2/release-group/?release=438042ef-7ccc-4d03-9391-4f66427b2055", self.opener.get_url())
+        self.assertEqual("http://musicbrainz.org/ws/2/release-group/?release=438042ef-7ccc-4d03-9391-4f66427b2055",
+                         self.m.request_history.pop().url)
 
         release = "438042ef-7ccc-4d03-9391-4f66427b2055"
         rel_type = "ep"
         musicbrainzngs.browse_release_groups(release=release, release_type=rel_type)
-        self.assertEqual("http://musicbrainz.org/ws/2/release-group/?release=438042ef-7ccc-4d03-9391-4f66427b2055&type=ep", self.opener.get_url())
+        self.assertEqual("http://musicbrainz.org/ws/2/release-group/?release=438042ef-7ccc-4d03-9391-4f66427b2055&type=ep",
+                         self.m.request_history.pop().url)
 
     def test_browse_url(self):
         resource = "http://www.queenonline.com"
         musicbrainzngs.browse_urls(resource=resource)
-        self.assertEqual("http://musicbrainz.org/ws/2/url/?resource=http%3A%2F%2Fwww.queenonline.com", self.opener.get_url())
+        self.assertEqual("http://musicbrainz.org/ws/2/url/?resource=http%3A%2F%2Fwww.queenonline.com",
+                         self.m.request_history.pop().url)
 
         # Resource is urlencoded, including ? and =
         resource = "http://www.splendidezine.com/review.html?reviewid=1109588405202831"
         musicbrainzngs.browse_urls(resource=resource)
-        self.assertEqual("http://musicbrainz.org/ws/2/url/?resource=http%3A%2F%2Fwww.splendidezine.com%2Freview.html%3Freviewid%3D1109588405202831", self.opener.get_url())
+        self.assertEqual("http://musicbrainz.org/ws/2/url/?resource=http%3A%2F%2Fwww.splendidezine.com%2Freview.html%3Freviewid%3D1109588405202831",
+                         self.m.request_history.pop().url)
 
     def test_browse_work(self):
         artist = "0383dadf-2a4e-4d10-a46a-e9e041da8eb3"
         musicbrainzngs.browse_works(artist=artist)
-        self.assertEqual("http://musicbrainz.org/ws/2/work/?artist=0383dadf-2a4e-4d10-a46a-e9e041da8eb3", self.opener.get_url())
+        self.assertEqual("http://musicbrainz.org/ws/2/work/?artist=0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+             self.m.request_history.pop().url)
 
     def test_browse_includes_is_subset_of_includes(self):
         """Check that VALID_BROWSE_INCLUDES is a strict subset of

--- a/test/test_browse.py
+++ b/test/test_browse.py
@@ -22,19 +22,19 @@ class BrowseTest(_common.RequestsMockingTestCase):
         area = "74e50e58-5deb-4b99-93a2-decbb365c07f"
         musicbrainzngs.browse_events(area=area)
         self.assertEqual("http://musicbrainz.org/ws/2/event/?area=74e50e58-5deb-4b99-93a2-decbb365c07f",
-                         self.m.request_history.pop().url)
+                         self.last_url)
 
     def test_browse_includes(self):
         area = "74e50e58-5deb-4b99-93a2-decbb365c07f"
         musicbrainzngs.browse_events(area=area, includes=["aliases", "area-rels"])
         self.assertEqual("http://musicbrainz.org/ws/2/event/?area=74e50e58-5deb-4b99-93a2-decbb365c07f&inc=aliases+area-rels",
-                         self.m.request_history.pop().url)
+                         self.last_url)
 
     def test_browse_single_include(self):
         area = "74e50e58-5deb-4b99-93a2-decbb365c07f"
         musicbrainzngs.browse_events(area=area, includes="aliases")
         self.assertEqual("http://musicbrainz.org/ws/2/event/?area=74e50e58-5deb-4b99-93a2-decbb365c07f&inc=aliases",
-                         self.m.request_history.pop().url)
+                         self.last_url)
 
     def test_browse_multiple_by(self):
         """It is an error to choose multiple entities to browse by"""
@@ -46,127 +46,127 @@ class BrowseTest(_common.RequestsMockingTestCase):
         area = "74e50e58-5deb-4b99-93a2-decbb365c07f"
         musicbrainzngs.browse_events(area=area, limit=50, offset=100)
         self.assertEqual("http://musicbrainz.org/ws/2/event/?area=74e50e58-5deb-4b99-93a2-decbb365c07f&limit=50&offset=100",
-                         self.m.request_history.pop().url)
+                         self.last_url)
 
     def test_browse_artist(self):
         release = "9ace7c8c-55b4-4c5d-9aa8-e573a5dde9ad"
         musicbrainzngs.browse_artists(release=release)
         self.assertEqual("http://musicbrainz.org/ws/2/artist/?release=9ace7c8c-55b4-4c5d-9aa8-e573a5dde9ad",
-                         self.m.request_history.pop().url)
+                         self.last_url)
 
         recording = "6da2cc31-9b12-4b66-9e26-074150f73406"
         musicbrainzngs.browse_artists(recording=recording)
         self.assertEqual("http://musicbrainz.org/ws/2/artist/?recording=6da2cc31-9b12-4b66-9e26-074150f73406",
-                         self.m.request_history.pop().url)
+                         self.last_url)
 
         release_group = "44c90c72-76b5-3c13-890e-3d37f21c10c9"
         musicbrainzngs.browse_artists(release_group=release_group)
         self.assertEqual("http://musicbrainz.org/ws/2/artist/?release-group=44c90c72-76b5-3c13-890e-3d37f21c10c9",
-                         self.m.request_history.pop().url)
+                         self.last_url)
 
         work = "deb27b88-cf41-4f7c-b3aa-bc3268bc3c02"
         musicbrainzngs.browse_artists(work=work)
         self.assertEqual("http://musicbrainz.org/ws/2/artist/?work=deb27b88-cf41-4f7c-b3aa-bc3268bc3c02",
-                         self.m.request_history.pop().url)
+                         self.last_url)
 
     def test_browse_event(self):
         area = "f03d09b3-39dc-4083-afd6-159e3f0d462f"
         musicbrainzngs.browse_events(area=area)
         self.assertEqual("http://musicbrainz.org/ws/2/event/?area=f03d09b3-39dc-4083-afd6-159e3f0d462f",
-                         self.m.request_history.pop().url)
+                         self.last_url)
 
         artist = "0383dadf-2a4e-4d10-a46a-e9e041da8eb3"
         musicbrainzngs.browse_events(artist=artist)
         self.assertEqual("http://musicbrainz.org/ws/2/event/?artist=0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                         self.m.request_history.pop().url)
+                         self.last_url)
 
         place = "8a6161bb-fb50-4234-82c5-1e24ab342499"
         musicbrainzngs.browse_events(place=place)
         self.assertEqual("http://musicbrainz.org/ws/2/event/?place=8a6161bb-fb50-4234-82c5-1e24ab342499",
-                         self.m.request_history.pop().url)
+                         self.last_url)
 
     def test_browse_label(self):
         release = "c9550260-b7ae-4670-ac24-731c19e76b59"
         musicbrainzngs.browse_labels(release=release)
         self.assertEqual("http://musicbrainz.org/ws/2/label/?release=c9550260-b7ae-4670-ac24-731c19e76b59",
-                         self.m.request_history.pop().url)
+                         self.last_url)
 
     def test_browse_recording(self):
         artist = "47f67b22-affe-4fe1-9d25-853d69bc0ee3"
         musicbrainzngs.browse_recordings(artist=artist)
         self.assertEqual("http://musicbrainz.org/ws/2/recording/?artist=47f67b22-affe-4fe1-9d25-853d69bc0ee3",
-                         self.m.request_history.pop().url)
+                         self.last_url)
 
         release = "438042ef-7ccc-4d03-9391-4f66427b2055"
         musicbrainzngs.browse_recordings(release=release)
         self.assertEqual("http://musicbrainz.org/ws/2/recording/?release=438042ef-7ccc-4d03-9391-4f66427b2055",
-                         self.m.request_history.pop().url)
+                         self.last_url)
 
     def test_browse_place(self):
         area = "74e50e58-5deb-4b99-93a2-decbb365c07f"
         musicbrainzngs.browse_places(area=area)
         self.assertEqual("http://musicbrainz.org/ws/2/place/?area=74e50e58-5deb-4b99-93a2-decbb365c07f",
-                         self.m.request_history.pop().url)
+                         self.last_url)
 
 
     def test_browse_release(self):
         artist = "47f67b22-affe-4fe1-9d25-853d69bc0ee3"
         musicbrainzngs.browse_releases(artist=artist)
         self.assertEqual("http://musicbrainz.org/ws/2/release/?artist=47f67b22-affe-4fe1-9d25-853d69bc0ee3",
-                         self.m.request_history.pop().url)
+                         self.last_url)
         musicbrainzngs.browse_releases(track_artist=artist)
         self.assertEqual("http://musicbrainz.org/ws/2/release/?track_artist=47f67b22-affe-4fe1-9d25-853d69bc0ee3",
-                         self.m.request_history.pop().url)
+                         self.last_url)
 
         label = "713c4a95-6616-442b-9cf6-14e1ddfd5946"
         musicbrainzngs.browse_releases(label=label)
         self.assertEqual("http://musicbrainz.org/ws/2/release/?label=713c4a95-6616-442b-9cf6-14e1ddfd5946",
-                         self.m.request_history.pop().url)
+                         self.last_url)
 
         recording = "7484fcfd-1968-4401-a44d-d1edcc580518"
         musicbrainzngs.browse_releases(recording=recording)
         self.assertEqual("http://musicbrainz.org/ws/2/release/?recording=7484fcfd-1968-4401-a44d-d1edcc580518",
-                         self.m.request_history.pop().url)
+                         self.last_url)
 
         release_group = "1c1b54f7-e56a-3ce8-b62c-e45c378e7f76"
         musicbrainzngs.browse_releases(release_group=release_group)
         self.assertEqual("http://musicbrainz.org/ws/2/release/?release-group=1c1b54f7-e56a-3ce8-b62c-e45c378e7f76",
-                         self.m.request_history.pop().url)
+                         self.last_url)
 
     def test_browse_release_group(self):
         artist = "47f67b22-affe-4fe1-9d25-853d69bc0ee3"
         musicbrainzngs.browse_release_groups(artist=artist)
         self.assertEqual("http://musicbrainz.org/ws/2/release-group/?artist=47f67b22-affe-4fe1-9d25-853d69bc0ee3",
-                         self.m.request_history.pop().url)
+                         self.last_url)
 
         release = "438042ef-7ccc-4d03-9391-4f66427b2055"
         musicbrainzngs.browse_release_groups(release=release)
         self.assertEqual("http://musicbrainz.org/ws/2/release-group/?release=438042ef-7ccc-4d03-9391-4f66427b2055",
-                         self.m.request_history.pop().url)
+                         self.last_url)
 
         release = "438042ef-7ccc-4d03-9391-4f66427b2055"
         rel_type = "ep"
         musicbrainzngs.browse_release_groups(release=release, release_type=rel_type)
         self.assertEqual("http://musicbrainz.org/ws/2/release-group/?release=438042ef-7ccc-4d03-9391-4f66427b2055&type=ep",
-                         self.m.request_history.pop().url)
+                         self.last_url)
 
     def test_browse_url(self):
         resource = "http://www.queenonline.com"
         musicbrainzngs.browse_urls(resource=resource)
         self.assertEqual("http://musicbrainz.org/ws/2/url/?resource=http%3A%2F%2Fwww.queenonline.com",
-                         self.m.request_history.pop().url)
+                         self.last_url)
 
         # Resource is urlencoded, including ? and =
         resource = "http://www.splendidezine.com/review.html?reviewid=1109588405202831"
         musicbrainzngs.browse_urls(resource=resource)
         self.assertEqual("http://musicbrainz.org/ws/2/url/?resource=http%3A%2F%2Fwww.splendidezine.com%2Freview.html%3Freviewid%3D1109588405202831",
-                         self.m.request_history.pop().url)
+                         self.last_url)
 
     def test_browse_work(self):
         artist = "0383dadf-2a4e-4d10-a46a-e9e041da8eb3"
         musicbrainzngs.browse_works(artist=artist)
         self.assertEqual("http://musicbrainz.org/ws/2/work/?artist=0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-             self.m.request_history.pop().url)
+             self.last_url)
 
     def test_browse_includes_is_subset_of_includes(self):
         """Check that VALID_BROWSE_INCLUDES is a strict subset of

--- a/test/test_browse.py
+++ b/test/test_browse.py
@@ -45,8 +45,7 @@ class BrowseTest(_common.RequestsMockingTestCase):
         """Limit and offset values"""
         area = "74e50e58-5deb-4b99-93a2-decbb365c07f"
         musicbrainzngs.browse_events(area=area, limit=50, offset=100)
-        # TODO: I had to switch the order of query arguments here
-        self.assertEqual("http://musicbrainz.org/ws/2/event/?offset=100&limit=50&area=74e50e58-5deb-4b99-93a2-decbb365c07f",
+        self.assertEqual("http://musicbrainz.org/ws/2/event/?area=74e50e58-5deb-4b99-93a2-decbb365c07f&limit=50&offset=100",
                          self.m.request_history.pop().url)
 
     def test_browse_artist(self):

--- a/test/test_caa.py
+++ b/test/test_caa.py
@@ -8,107 +8,111 @@ from musicbrainzngs import compat
 from musicbrainzngs.musicbrainz import _version
 import musicbrainzngs
 from test import _common
+import requests_mock
+from re import compile
 
+
+@requests_mock.Mocker()
 class CaaTest(unittest.TestCase):
+    def setUp(self):
+        musicbrainzngs.set_useragent("a", "1")
+        musicbrainzngs.set_rate_limit(False)
 
-    def test_get_list(self):
+    def test_get_list(self, m):
         # check the url and response for a listing
         resp = '{"images":[]}'
-        self.opener = _common.FakeOpener(resp)
-        musicbrainzngs.compat.build_opener = lambda *args: self.opener
+        m.get(compile("coverartarchive.org/"), text=resp)
         res = caa.get_image_list("8ec178f4-a8e8-4f22-bcba-1964466ef214")
-        self.assertEqual("http://coverartarchive.org/release/8ec178f4-a8e8-4f22-bcba-1964466ef214", self.opener.myurl)
+        self.assertEqual("http://coverartarchive.org/release/8ec178f4-a8e8-4f22-bcba-1964466ef214",
+                         m.request_history.pop().url)
         self.assertEqual(1, len(res))
         self.assertTrue("images" in res)
 
-    def test_get_release_group_list(self):
+    def test_get_release_group_list(self, m):
         # check the url and response for a listing
         resp = '{"images":[], "release": "foo"}'
-        self.opener = _common.FakeOpener(resp)
-        musicbrainzngs.compat.build_opener = lambda *args: self.opener
+        m.get(compile("coverartarchive.org/"), text=resp)
         res = caa.get_release_group_image_list("8ec178f4-a8e8-4f22-bcba-1964466ef214")
-        self.assertEqual("http://coverartarchive.org/release-group/8ec178f4-a8e8-4f22-bcba-1964466ef214", self.opener.myurl)
+        self.assertEqual("http://coverartarchive.org/release-group/8ec178f4-a8e8-4f22-bcba-1964466ef214",
+                         m.request_history.pop().url)
         self.assertEqual(2, len(res))
         self.assertTrue("images" in res)
         self.assertEqual("foo", res["release"])
 
-    def test_list_none(self):
+    def test_list_none(self, m):
         """ When CAA gives a 404 error, pass it through."""
+        m.get(compile("coverartarchive.org/release/8ec178f4-a8e8-4f22-bcba-19644XXXXXX"),
+              status_code=404)
 
-        exc = compat.HTTPError("", 404, "", "", _common.StringIO.StringIO(""))
-        self.opener = _common.FakeOpener(exception=musicbrainzngs.ResponseError(cause=exc))
-        musicbrainzngs.compat.build_opener = lambda *args: self.opener
         try:
             res = caa.get_image_list("8ec178f4-a8e8-4f22-bcba-19644XXXXXX")
             self.assertTrue(False, "Expected an exception")
         except musicbrainzngs.ResponseError as e:
-            self.assertEqual(e.cause.code, 404)
+            self.assertEqual(e.cause.response.status_code, 404)
 
-    def test_list_baduuid(self):
-        exc = compat.HTTPError("", 400, "", "", _common.StringIO.StringIO(""))
-        self.opener = _common.FakeOpener(exception=musicbrainzngs.ResponseError(cause=exc))
-        musicbrainzngs.compat.build_opener = lambda *args: self.opener
+    def test_list_baduuid(self, m):
+        m.get(compile("coverartarchive.org/release/8ec178f4-a8e8-4f22-bcba-19644XXXXXX"),
+              status_code=400)
         try:
             res = caa.get_image_list("8ec178f4-a8e8-4f22-bcba-19644XXXXXX")
             self.assertTrue(False, "Expected an exception")
         except musicbrainzngs.ResponseError as e:
-            self.assertEqual(e.cause.code, 400)
+            self.assertEqual(e.cause.response.status_code, 400)
 
-    def test_set_useragent(self):
+    def test_set_useragent(self, m):
         """ When a useragent is set it is sent with the request """
         musicbrainzngs.set_useragent("caa-test", "0.1")
 
         resp = '{"images":[]}'
-        self.opener = _common.FakeOpener(resp)
-        musicbrainzngs.compat.build_opener = lambda *args: self.opener
+        m.get(compile("coverartarchive.org/"), text=resp)
         res = caa.get_image_list("8ec178f4-a8e8-4f22-bcba-1964466ef214")
 
-        headers = dict(self.opener.headers)
-        self.assertTrue("User-agent" in headers)
-        self.assertEqual("caa-test/0.1 python-musicbrainzngs/%s" % _version, headers["User-agent"])
+        headers = dict(m.request_history.pop().headers)
+        self.assertTrue("User-Agent" in headers)
+        self.assertEqual("caa-test/0.1 python-musicbrainzngs/%s" % _version,
+                         headers["User-Agent"])
 
-    def test_coverid(self):
-        resp = 'some_image'
-        self.opener = _common.FakeOpener(resp)
-        musicbrainzngs.compat.build_opener = lambda *args: self.opener
+    def test_coverid(self, m):
+        resp = b'some_image'
+        m.get(compile("coverartarchive.org/"), content=resp)
         res = caa.get_image("8ec178f4-a8e8-4f22-bcba-1964466ef214", "1234")
 
-        self.assertEqual("http://coverartarchive.org/release/8ec178f4-a8e8-4f22-bcba-1964466ef214/1234", self.opener.myurl)
+        self.assertEqual("http://coverartarchive.org/release/8ec178f4-a8e8-4f22-bcba-1964466ef214/1234",
+                         m.request_history.pop().url)
         self.assertEqual(resp, res)
 
-    def test_get_size(self):
-        resp = 'some_image'
-        self.opener = _common.FakeOpener(resp)
-        musicbrainzngs.compat.build_opener = lambda *args: self.opener
+    def test_get_size(self, m):
+        resp = b'some_image'
+        m.get(compile("coverartarchive.org/"), content=resp)
         res = caa.get_image("8ec178f4-a8e8-4f22-bcba-1964466ef214", "1234", 250)
 
-        self.assertEqual("http://coverartarchive.org/release/8ec178f4-a8e8-4f22-bcba-1964466ef214/1234-250", self.opener.myurl)
+        self.assertEqual("http://coverartarchive.org/release/8ec178f4-a8e8-4f22-bcba-1964466ef214/1234-250",
+                         m.request_history.pop().url)
         self.assertEqual(resp, res)
 
-    def test_front(self):
-        resp = 'front_image'
-        self.opener = _common.FakeOpener(resp)
-        musicbrainzngs.compat.build_opener = lambda *args: self.opener
+    def test_front(self, m):
+        resp = b'front_image'
+        m.get(compile("coverartarchive.org/"), content=resp)
         res = caa.get_image_front("8ec178f4-a8e8-4f22-bcba-1964466ef214")
 
-        self.assertEqual("http://coverartarchive.org/release/8ec178f4-a8e8-4f22-bcba-1964466ef214/front", self.opener.myurl)
+        self.assertEqual("http://coverartarchive.org/release/8ec178f4-a8e8-4f22-bcba-1964466ef214/front",
+                         m.request_history.pop().url)
         self.assertEqual(resp, res)
 
-    def test_release_group_front(self):
-        resp = 'front_image'
-        self.opener = _common.FakeOpener(resp)
-        musicbrainzngs.compat.build_opener = lambda *args: self.opener
+    def test_release_group_front(self, m):
+        resp = b'front_image'
+        m.get(compile("coverartarchive.org/"), content=resp)
         res = caa.get_release_group_image_front("8ec178f4-a8e8-4f22-bcba-1964466ef214")
 
-        self.assertEqual("http://coverartarchive.org/release-group/8ec178f4-a8e8-4f22-bcba-1964466ef214/front", self.opener.myurl)
+        self.assertEqual("http://coverartarchive.org/release-group/8ec178f4-a8e8-4f22-bcba-1964466ef214/front",
+                         m.request_history.pop().url)
         self.assertEqual(resp, res)
 
-    def test_back(self):
-        resp = 'back_image'
-        self.opener = _common.FakeOpener(resp)
-        musicbrainzngs.compat.build_opener = lambda *args: self.opener
+    def test_back(self, m):
+        resp = b'back_image'
+        m.get(compile("coverartarchive.org/"), content=resp)
         res = caa.get_image_back("8ec178f4-a8e8-4f22-bcba-1964466ef214")
 
-        self.assertEqual("http://coverartarchive.org/release/8ec178f4-a8e8-4f22-bcba-1964466ef214/back", self.opener.myurl)
+        self.assertEqual("http://coverartarchive.org/release/8ec178f4-a8e8-4f22-bcba-1964466ef214/back",
+                         m.request_history.pop().url)
         self.assertEqual(resp, res)
-

--- a/test/test_collection.py
+++ b/test/test_collection.py
@@ -7,6 +7,8 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 import musicbrainzngs
 from musicbrainzngs import compat
 from test import _common
+import requests_mock
+from re import compile
 
 class CollectionTest(unittest.TestCase):
     """ Test that requesting collections works properly """
@@ -21,7 +23,7 @@ class CollectionTest(unittest.TestCase):
         self.assertEqual(musicbrainzngs.musicbrainz.AUTH_YES, ar)
 
         ar = musicbrainzngs.musicbrainz._get_auth_type("collection",
-                "foo/releases", [])
+                                                       "foo/releases", [])
         self.assertEqual(musicbrainzngs.musicbrainz.AUTH_IFSET, ar)
 
     def test_my_collections(self):
@@ -39,7 +41,7 @@ class CollectionTest(unittest.TestCase):
         musicbrainzngs.musicbrainz._mb_request = local_mb_request
         musicbrainzngs.get_collections()
         self.assertEqual(musicbrainzngs.musicbrainz.AUTH_YES,
-            params["auth_required"])
+                         params["auth_required"])
 
         musicbrainzngs.musicbrainz._mb_request = old_mb_request
 
@@ -63,31 +65,31 @@ class CollectionTest(unittest.TestCase):
         # i.e., We use whether auth() has been executed to determine if
         # the requested collection belongs to the user or not.
         self.assertEqual(musicbrainzngs.musicbrainz.AUTH_IFSET,
-                params["auth_required"])
+                         params["auth_required"])
 
         musicbrainzngs.musicbrainz._mb_request = old_mb_request
 
-    def test_no_collection(self):
+    @requests_mock.Mocker()
+    def test_no_collection(self, m):
         """ If a collection doesn't exist, you get a 404 """
+        m.get(compile("ws/2/collection/17905fdb-102d-40f0-91d3-eabcabc64f44"),
+              status_code=404)
 
-        exc = compat.HTTPError("", 404, "", "", _common.StringIO.StringIO(""))
-        self.opener = _common.FakeOpener(exception=musicbrainzngs.ResponseError(cause=exc))
-        musicbrainzngs.compat.build_opener = lambda *args: self.opener
         try:
             res = musicbrainzngs.get_releases_in_collection("17905fdb-102d-40f0-91d3-eabcabc64f44")
             self.assertTrue(False, "Expected an exception")
         except musicbrainzngs.ResponseError as e:
-            self.assertEqual(e.cause.code, 404)
+            self.assertEqual(e.cause.response.status_code, 404)
 
-    def test_private_collection(self):
+    @requests_mock.Mocker()
+    def test_private_collection(self, m):
         """ If you ask for a collection that is private, you should
         get a 401"""
+        m.get(compile("ws/2/collection/17905fdb-102d-40f0-91d3-eabcabc64fd3"),
+              status_code=401)
 
-        exc = compat.HTTPError("", 401, "", "", _common.StringIO.StringIO(""))
-        self.opener = _common.FakeOpener(exception=musicbrainzngs.AuthenticationError(cause=exc))
-        musicbrainzngs.compat.build_opener = lambda *args: self.opener
         try:
             res = musicbrainzngs.get_releases_in_collection("17905fdb-102d-40f0-91d3-eabcabc64fd3")
             self.assertTrue(False, "Expected an exception")
         except musicbrainzngs.AuthenticationError as e:
-            self.assertEqual(e.cause.code, 401)
+            self.assertEqual(e.cause.response.status_code, 401)

--- a/test/test_getentity.py
+++ b/test/test_getentity.py
@@ -6,36 +6,41 @@ import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 import musicbrainzngs
 from test import _common
+import requests_mock
+from re import compile
 
 
-class UrlTest(unittest.TestCase):
+class UrlTest(_common.RequestsMockingTestCase):
     """ Test that the correct URL is generated when a search query is made """
 
     def setUp(self):
-        self.opener = _common.FakeOpener("<response/>")
-        musicbrainzngs.compat.build_opener = lambda *args: self.opener
+        super(UrlTest, self).setUp()
 
         musicbrainzngs.set_useragent("a", "1")
         musicbrainzngs.set_rate_limit(False)
 
+        self.m.get(compile("ws/2/.*/*"), text="<response/>")
+
     def testGetArtist(self):
         artistid = "952a4205-023d-4235-897c-6fdb6f58dfaa"
         musicbrainzngs.get_artist_by_id(artistid)
-        self.assertEqual("http://musicbrainz.org/ws/2/artist/952a4205-023d-4235-897c-6fdb6f58dfaa", self.opener.get_url())
+        self.assertEqual("http://musicbrainz.org/ws/2/artist/952a4205-023d-4235-897c-6fdb6f58dfaa",
+                         self.m.request_history.pop().url)
 
         # Test an include
         musicbrainzngs.get_artist_by_id(artistid, "recordings")
-        self.assertEqual("http://musicbrainz.org/ws/2/artist/952a4205-023d-4235-897c-6fdb6f58dfaa?inc=recordings", self.opener.get_url())
+        self.assertEqual("http://musicbrainz.org/ws/2/artist/952a4205-023d-4235-897c-6fdb6f58dfaa?inc=recordings",
+                         self.m.request_history.pop().url)
 
         # More than one include
         musicbrainzngs.get_artist_by_id(artistid, ["recordings", "aliases"])
         expected ="http://musicbrainz.org/ws/2/artist/952a4205-023d-4235-897c-6fdb6f58dfaa?inc=recordings+aliases"
-        self.assertEqual(expected, self.opener.get_url())
+        self.assertEqual(expected, self.m.request_history.pop().url)
 
         # with valid filters
         musicbrainzngs.get_artist_by_id(artistid, ["release-groups"],
                 release_type=["album"])
-        self.assertTrue("type=album" in self.opener.get_url())
+        self.assertTrue("type=album" in self.m.request_history.pop().url)
 
         # with invalid filters
         self.assertRaises(musicbrainzngs.UsageError,
@@ -45,61 +50,75 @@ class UrlTest(unittest.TestCase):
     def testGetEvent(self):
         event_id = "a4a0927c-8ad7-48dd-883c-7126cc0b9c6b"
         musicbrainzngs.get_event_by_id(event_id)
-        self.assertEqual("http://musicbrainz.org/ws/2/event/a4a0927c-8ad7-48dd-883c-7126cc0b9c6b", self.opener.get_url())
+        self.assertEqual("http://musicbrainz.org/ws/2/event/a4a0927c-8ad7-48dd-883c-7126cc0b9c6b",
+                         self.m.request_history.pop().url)
 
         # one include
         musicbrainzngs.get_event_by_id(event_id, ["artist-rels"])
-        self.assertEqual("http://musicbrainz.org/ws/2/event/a4a0927c-8ad7-48dd-883c-7126cc0b9c6b?inc=artist-rels", self.opener.get_url())
+        self.assertEqual("http://musicbrainz.org/ws/2/event/a4a0927c-8ad7-48dd-883c-7126cc0b9c6b?inc=artist-rels",
+                         self.m.request_history.pop().url)
 
         musicbrainzngs.get_event_by_id(event_id, ["artist-rels", "event-rels", "ratings", "tags"])
-        self.assertEqual("http://musicbrainz.org/ws/2/event/a4a0927c-8ad7-48dd-883c-7126cc0b9c6b?inc=artist-rels+event-rels+ratings+tags", self.opener.get_url())
+        self.assertEqual("http://musicbrainz.org/ws/2/event/a4a0927c-8ad7-48dd-883c-7126cc0b9c6b?inc=artist-rels+event-rels+ratings+tags",
+                         self.m.request_history.pop().url)
 
     def testGetPlace(self):
         place_id = "43e166a5-a024-4cbb-9a1f-d4947b4ff489"
         musicbrainzngs.get_place_by_id(place_id)
-        self.assertEqual("http://musicbrainz.org/ws/2/place/43e166a5-a024-4cbb-9a1f-d4947b4ff489", self.opener.get_url())
+        self.assertEqual("http://musicbrainz.org/ws/2/place/43e166a5-a024-4cbb-9a1f-d4947b4ff489",
+                         self.m.request_history.pop().url)
 
         musicbrainzngs.get_place_by_id(place_id, ["event-rels"])
-        self.assertEqual("http://musicbrainz.org/ws/2/place/43e166a5-a024-4cbb-9a1f-d4947b4ff489?inc=event-rels", self.opener.get_url())
+        self.assertEqual("http://musicbrainz.org/ws/2/place/43e166a5-a024-4cbb-9a1f-d4947b4ff489?inc=event-rels",
+                         self.m.request_history.pop().url)
 
     def testGetLabel(self):
         label_id = "aab2e720-bdd2-4565-afc2-460743585f16"
         musicbrainzngs.get_label_by_id(label_id)
-        self.assertEqual("http://musicbrainz.org/ws/2/label/aab2e720-bdd2-4565-afc2-460743585f16", self.opener.get_url())
+        self.assertEqual("http://musicbrainz.org/ws/2/label/aab2e720-bdd2-4565-afc2-460743585f16",
+                         self.m.request_history.pop().url)
 
         # one include
         musicbrainzngs.get_label_by_id(label_id, "releases")
-        self.assertEqual("http://musicbrainz.org/ws/2/label/aab2e720-bdd2-4565-afc2-460743585f16?inc=releases", self.opener.get_url())
+        self.assertEqual("http://musicbrainz.org/ws/2/label/aab2e720-bdd2-4565-afc2-460743585f16?inc=releases",
+                         self.m.request_history.pop().url)
 
         # with valid filters
         musicbrainzngs.get_label_by_id(label_id, ["releases"],
-                release_type=["ep", "single"], release_status=["official"])
-        self.assertTrue("type=ep%7Csingle" in self.opener.get_url())
-        self.assertTrue("status=official" in self.opener.get_url())
+                                       release_type=["ep", "single"],
+                                       release_status=["official"])
+        url = self.m.request_history.pop().url
+        self.assertTrue("type=ep%7Csingle" in url)
+        self.assertTrue("status=official" in url)
 
     def testGetRecording(self):
         musicbrainzngs.get_recording_by_id("93468a09-9662-4886-a227-56a2ad1c5246")
-        self.assertEqual("http://musicbrainz.org/ws/2/recording/93468a09-9662-4886-a227-56a2ad1c5246", self.opener.get_url())
+        self.assertEqual("http://musicbrainz.org/ws/2/recording/93468a09-9662-4886-a227-56a2ad1c5246",
+                         self.m.request_history.pop().url)
 
         # one include
         musicbrainzngs.get_recording_by_id("93468a09-9662-4886-a227-56a2ad1c5246", includes=["artists"])
-        self.assertEqual("http://musicbrainz.org/ws/2/recording/93468a09-9662-4886-a227-56a2ad1c5246?inc=artists", self.opener.get_url())
+        self.assertEqual("http://musicbrainz.org/ws/2/recording/93468a09-9662-4886-a227-56a2ad1c5246?inc=artists",
+                         self.m.request_history.pop().url)
 
 
     def testGetReleasegroup(self):
         musicbrainzngs.get_release_group_by_id("9377d65d-ffd5-35d6-b64d-43f86ef9188d")
-        self.assertEqual("http://musicbrainz.org/ws/2/release-group/9377d65d-ffd5-35d6-b64d-43f86ef9188d", self.opener.get_url())
+        self.assertEqual("http://musicbrainz.org/ws/2/release-group/9377d65d-ffd5-35d6-b64d-43f86ef9188d",
+                         self.m.request_history.pop().url)
 
         # one include
         release_group_id = "9377d65d-ffd5-35d6-b64d-43f86ef9188d"
         musicbrainzngs.get_release_group_by_id(release_group_id,
                 includes=["artists"])
-        self.assertEqual("http://musicbrainz.org/ws/2/release-group/9377d65d-ffd5-35d6-b64d-43f86ef9188d?inc=artists", self.opener.get_url())
+        self.assertEqual("http://musicbrainz.org/ws/2/release-group/9377d65d-ffd5-35d6-b64d-43f86ef9188d?inc=artists",
+                         self.m.request_history.pop().url)
 
         # with valid filters
         musicbrainzngs.get_release_group_by_id(release_group_id,
-                release_type=["compilation", "live"])
-        self.assertTrue("type=compilation%7Clive" in self.opener.get_url())
+                                               release_type=["compilation", "live"])
+        self.assertTrue("type=compilation%7Clive" in
+                        self.m.request_history.pop().url)
 
         # with invalid filters
         self.assertRaises(musicbrainzngs.UsageError,
@@ -109,39 +128,49 @@ class UrlTest(unittest.TestCase):
 
     def testGetWork(self):
         musicbrainzngs.get_work_by_id("c6dfad5a-f915-41c7-a1c0-e2b606948e69")
-        self.assertEqual("http://musicbrainz.org/ws/2/work/c6dfad5a-f915-41c7-a1c0-e2b606948e69", self.opener.get_url())
+        self.assertEqual("http://musicbrainz.org/ws/2/work/c6dfad5a-f915-41c7-a1c0-e2b606948e69",
+                         self.m.request_history.pop().url)
 
     def testGetByDiscid(self):
         musicbrainzngs.get_releases_by_discid("I5l9cCSFccLKFEKS.7wqSZAorPU-")
-        self.assertEqual("http://musicbrainz.org/ws/2/discid/I5l9cCSFccLKFEKS.7wqSZAorPU-", self.opener.get_url())
+        self.assertEqual("http://musicbrainz.org/ws/2/discid/I5l9cCSFccLKFEKS.7wqSZAorPU-",
+                         self.m.request_history.pop().url)
 
         includes = ["artists"]
         musicbrainzngs.get_releases_by_discid("I5l9cCSFccLKFEKS.7wqSZAorPU-", includes)
-        self.assertEqual("http://musicbrainz.org/ws/2/discid/I5l9cCSFccLKFEKS.7wqSZAorPU-?inc=artists", self.opener.get_url())
+        self.assertEqual("http://musicbrainz.org/ws/2/discid/I5l9cCSFccLKFEKS.7wqSZAorPU-?inc=artists",
+                         self.m.request_history.pop().url)
 
         musicbrainzngs.get_releases_by_discid("discid", toc="toc")
-        self.assertEqual("http://musicbrainz.org/ws/2/discid/discid?toc=toc", self.opener.get_url())
+        self.assertEqual("http://musicbrainz.org/ws/2/discid/discid?toc=toc",
+                         self.m.request_history.pop().url)
 
         musicbrainzngs.get_releases_by_discid("discid", toc="toc", cdstubs=False)
-        self.assertEqual("http://musicbrainz.org/ws/2/discid/discid?cdstubs=no&toc=toc", self.opener.get_url())
+        # TODO: I had to reorder query parameters here
+        self.assertEqual("http://musicbrainz.org/ws/2/discid/discid?toc=toc&cdstubs=no",
+                         self.m.request_history.pop().url)
 
 
     def testGetInstrument(self):
 
         musicbrainzngs.get_instrument_by_id("6505f98c-f698-4406-8bf4-8ca43d05c36f")
-        self.assertEqual("http://musicbrainz.org/ws/2/instrument/6505f98c-f698-4406-8bf4-8ca43d05c36f", self.opener.get_url())
+        self.assertEqual("http://musicbrainz.org/ws/2/instrument/6505f98c-f698-4406-8bf4-8ca43d05c36f",
+                         self.m.request_history.pop().url)
 
         # Tags
         musicbrainzngs.get_instrument_by_id("6505f98c-f698-4406-8bf4-8ca43d05c36f", includes="tags")
-        self.assertEqual("http://musicbrainz.org/ws/2/instrument/6505f98c-f698-4406-8bf4-8ca43d05c36f?inc=tags", self.opener.get_url())
+        self.assertEqual("http://musicbrainz.org/ws/2/instrument/6505f98c-f698-4406-8bf4-8ca43d05c36f?inc=tags",
+                         self.m.request_history.pop().url)
 
         # some rels
         musicbrainzngs.get_instrument_by_id("6505f98c-f698-4406-8bf4-8ca43d05c36f", includes=["instrument-rels", "url-rels"])
-        self.assertEqual("http://musicbrainz.org/ws/2/instrument/6505f98c-f698-4406-8bf4-8ca43d05c36f?inc=instrument-rels+url-rels", self.opener.get_url())
+        self.assertEqual("http://musicbrainz.org/ws/2/instrument/6505f98c-f698-4406-8bf4-8ca43d05c36f?inc=instrument-rels+url-rels",
+                         self.m.request_history.pop().url)
 
         # alias, annotation
         musicbrainzngs.get_instrument_by_id("d00cec5f-f9bc-4235-a54f-6639a02d4e4c", includes=["aliases", "annotation"])
-        self.assertEqual("http://musicbrainz.org/ws/2/instrument/d00cec5f-f9bc-4235-a54f-6639a02d4e4c?inc=aliases+annotation", self.opener.get_url())
+        self.assertEqual("http://musicbrainz.org/ws/2/instrument/d00cec5f-f9bc-4235-a54f-6639a02d4e4c?inc=aliases+annotation",
+                         self.m.request_history.pop().url)
 
         # Ratings are used on almost all other entites but instrument
         self.assertRaises(musicbrainzngs.UsageError,

--- a/test/test_getentity.py
+++ b/test/test_getentity.py
@@ -25,22 +25,22 @@ class UrlTest(_common.RequestsMockingTestCase):
         artistid = "952a4205-023d-4235-897c-6fdb6f58dfaa"
         musicbrainzngs.get_artist_by_id(artistid)
         self.assertEqual("http://musicbrainz.org/ws/2/artist/952a4205-023d-4235-897c-6fdb6f58dfaa",
-                         self.m.request_history.pop().url)
+                         self.last_url)
 
         # Test an include
         musicbrainzngs.get_artist_by_id(artistid, "recordings")
         self.assertEqual("http://musicbrainz.org/ws/2/artist/952a4205-023d-4235-897c-6fdb6f58dfaa?inc=recordings",
-                         self.m.request_history.pop().url)
+                         self.last_url)
 
         # More than one include
         musicbrainzngs.get_artist_by_id(artistid, ["recordings", "aliases"])
         expected ="http://musicbrainz.org/ws/2/artist/952a4205-023d-4235-897c-6fdb6f58dfaa?inc=recordings+aliases"
-        self.assertEqual(expected, self.m.request_history.pop().url)
+        self.assertEqual(expected, self.last_url)
 
         # with valid filters
         musicbrainzngs.get_artist_by_id(artistid, ["release-groups"],
                 release_type=["album"])
-        self.assertTrue("type=album" in self.m.request_history.pop().url)
+        self.assertTrue("type=album" in self.last_url)
 
         # with invalid filters
         self.assertRaises(musicbrainzngs.UsageError,
@@ -51,74 +51,74 @@ class UrlTest(_common.RequestsMockingTestCase):
         event_id = "a4a0927c-8ad7-48dd-883c-7126cc0b9c6b"
         musicbrainzngs.get_event_by_id(event_id)
         self.assertEqual("http://musicbrainz.org/ws/2/event/a4a0927c-8ad7-48dd-883c-7126cc0b9c6b",
-                         self.m.request_history.pop().url)
+                         self.last_url)
 
         # one include
         musicbrainzngs.get_event_by_id(event_id, ["artist-rels"])
         self.assertEqual("http://musicbrainz.org/ws/2/event/a4a0927c-8ad7-48dd-883c-7126cc0b9c6b?inc=artist-rels",
-                         self.m.request_history.pop().url)
+                         self.last_url)
 
         musicbrainzngs.get_event_by_id(event_id, ["artist-rels", "event-rels", "ratings", "tags"])
         self.assertEqual("http://musicbrainz.org/ws/2/event/a4a0927c-8ad7-48dd-883c-7126cc0b9c6b?inc=artist-rels+event-rels+ratings+tags",
-                         self.m.request_history.pop().url)
+                         self.last_url)
 
     def testGetPlace(self):
         place_id = "43e166a5-a024-4cbb-9a1f-d4947b4ff489"
         musicbrainzngs.get_place_by_id(place_id)
         self.assertEqual("http://musicbrainz.org/ws/2/place/43e166a5-a024-4cbb-9a1f-d4947b4ff489",
-                         self.m.request_history.pop().url)
+                         self.last_url)
 
         musicbrainzngs.get_place_by_id(place_id, ["event-rels"])
         self.assertEqual("http://musicbrainz.org/ws/2/place/43e166a5-a024-4cbb-9a1f-d4947b4ff489?inc=event-rels",
-                         self.m.request_history.pop().url)
+                         self.last_url)
 
     def testGetLabel(self):
         label_id = "aab2e720-bdd2-4565-afc2-460743585f16"
         musicbrainzngs.get_label_by_id(label_id)
         self.assertEqual("http://musicbrainz.org/ws/2/label/aab2e720-bdd2-4565-afc2-460743585f16",
-                         self.m.request_history.pop().url)
+                         self.last_url)
 
         # one include
         musicbrainzngs.get_label_by_id(label_id, "releases")
         self.assertEqual("http://musicbrainz.org/ws/2/label/aab2e720-bdd2-4565-afc2-460743585f16?inc=releases",
-                         self.m.request_history.pop().url)
+                         self.last_url)
 
         # with valid filters
         musicbrainzngs.get_label_by_id(label_id, ["releases"],
                                        release_type=["ep", "single"],
                                        release_status=["official"])
-        url = self.m.request_history.pop().url
+        url = self.last_url
         self.assertTrue("type=ep%7Csingle" in url)
         self.assertTrue("status=official" in url)
 
     def testGetRecording(self):
         musicbrainzngs.get_recording_by_id("93468a09-9662-4886-a227-56a2ad1c5246")
         self.assertEqual("http://musicbrainz.org/ws/2/recording/93468a09-9662-4886-a227-56a2ad1c5246",
-                         self.m.request_history.pop().url)
+                         self.last_url)
 
         # one include
         musicbrainzngs.get_recording_by_id("93468a09-9662-4886-a227-56a2ad1c5246", includes=["artists"])
         self.assertEqual("http://musicbrainz.org/ws/2/recording/93468a09-9662-4886-a227-56a2ad1c5246?inc=artists",
-                         self.m.request_history.pop().url)
+                         self.last_url)
 
 
     def testGetReleasegroup(self):
         musicbrainzngs.get_release_group_by_id("9377d65d-ffd5-35d6-b64d-43f86ef9188d")
         self.assertEqual("http://musicbrainz.org/ws/2/release-group/9377d65d-ffd5-35d6-b64d-43f86ef9188d",
-                         self.m.request_history.pop().url)
+                         self.last_url)
 
         # one include
         release_group_id = "9377d65d-ffd5-35d6-b64d-43f86ef9188d"
         musicbrainzngs.get_release_group_by_id(release_group_id,
                 includes=["artists"])
         self.assertEqual("http://musicbrainz.org/ws/2/release-group/9377d65d-ffd5-35d6-b64d-43f86ef9188d?inc=artists",
-                         self.m.request_history.pop().url)
+                         self.last_url)
 
         # with valid filters
         musicbrainzngs.get_release_group_by_id(release_group_id,
                                                release_type=["compilation", "live"])
         self.assertTrue("type=compilation%7Clive" in
-                        self.m.request_history.pop().url)
+                        self.last_url)
 
         # with invalid filters
         self.assertRaises(musicbrainzngs.UsageError,
@@ -129,47 +129,47 @@ class UrlTest(_common.RequestsMockingTestCase):
     def testGetWork(self):
         musicbrainzngs.get_work_by_id("c6dfad5a-f915-41c7-a1c0-e2b606948e69")
         self.assertEqual("http://musicbrainz.org/ws/2/work/c6dfad5a-f915-41c7-a1c0-e2b606948e69",
-                         self.m.request_history.pop().url)
+                         self.last_url)
 
     def testGetByDiscid(self):
         musicbrainzngs.get_releases_by_discid("I5l9cCSFccLKFEKS.7wqSZAorPU-")
         self.assertEqual("http://musicbrainz.org/ws/2/discid/I5l9cCSFccLKFEKS.7wqSZAorPU-",
-                         self.m.request_history.pop().url)
+                         self.last_url)
 
         includes = ["artists"]
         musicbrainzngs.get_releases_by_discid("I5l9cCSFccLKFEKS.7wqSZAorPU-", includes)
         self.assertEqual("http://musicbrainz.org/ws/2/discid/I5l9cCSFccLKFEKS.7wqSZAorPU-?inc=artists",
-                         self.m.request_history.pop().url)
+                         self.last_url)
 
         musicbrainzngs.get_releases_by_discid("discid", toc="toc")
         self.assertEqual("http://musicbrainz.org/ws/2/discid/discid?toc=toc",
-                         self.m.request_history.pop().url)
+                         self.last_url)
 
         musicbrainzngs.get_releases_by_discid("discid", toc="toc", cdstubs=False)
         self.assertEqual("http://musicbrainz.org/ws/2/discid/discid?cdstubs=no&toc=toc",
-                         self.m.request_history.pop().url)
+                         self.last_url)
 
 
     def testGetInstrument(self):
 
         musicbrainzngs.get_instrument_by_id("6505f98c-f698-4406-8bf4-8ca43d05c36f")
         self.assertEqual("http://musicbrainz.org/ws/2/instrument/6505f98c-f698-4406-8bf4-8ca43d05c36f",
-                         self.m.request_history.pop().url)
+                         self.last_url)
 
         # Tags
         musicbrainzngs.get_instrument_by_id("6505f98c-f698-4406-8bf4-8ca43d05c36f", includes="tags")
         self.assertEqual("http://musicbrainz.org/ws/2/instrument/6505f98c-f698-4406-8bf4-8ca43d05c36f?inc=tags",
-                         self.m.request_history.pop().url)
+                         self.last_url)
 
         # some rels
         musicbrainzngs.get_instrument_by_id("6505f98c-f698-4406-8bf4-8ca43d05c36f", includes=["instrument-rels", "url-rels"])
         self.assertEqual("http://musicbrainz.org/ws/2/instrument/6505f98c-f698-4406-8bf4-8ca43d05c36f?inc=instrument-rels+url-rels",
-                         self.m.request_history.pop().url)
+                         self.last_url)
 
         # alias, annotation
         musicbrainzngs.get_instrument_by_id("d00cec5f-f9bc-4235-a54f-6639a02d4e4c", includes=["aliases", "annotation"])
         self.assertEqual("http://musicbrainz.org/ws/2/instrument/d00cec5f-f9bc-4235-a54f-6639a02d4e4c?inc=aliases+annotation",
-                         self.m.request_history.pop().url)
+                         self.last_url)
 
         # Ratings are used on almost all other entites but instrument
         self.assertRaises(musicbrainzngs.UsageError,

--- a/test/test_getentity.py
+++ b/test/test_getentity.py
@@ -146,8 +146,7 @@ class UrlTest(_common.RequestsMockingTestCase):
                          self.m.request_history.pop().url)
 
         musicbrainzngs.get_releases_by_discid("discid", toc="toc", cdstubs=False)
-        # TODO: I had to reorder query parameters here
-        self.assertEqual("http://musicbrainz.org/ws/2/discid/discid?toc=toc&cdstubs=no",
+        self.assertEqual("http://musicbrainz.org/ws/2/discid/discid?cdstubs=no&toc=toc",
                          self.m.request_history.pop().url)
 
 

--- a/test/test_mbxml_collection.py
+++ b/test/test_mbxml_collection.py
@@ -25,27 +25,27 @@ class UrlTest(_common.RequestsMockingTestCase):
     def testGetCollection(self):
         musicbrainzngs.get_releases_in_collection("0b15c97c-8eb8-4b4f-81c3-0eb24266a2ac")
         self.assertEqual("http://musicbrainz.org/ws/2/collection/0b15c97c-8eb8-4b4f-81c3-0eb24266a2ac/releases",
-                         self.m.request_history.pop().url)
+                         self.last_url)
 
         musicbrainzngs.get_works_in_collection("898676a6-bc79-4fe2-98ae-79c5940fe1a2")
         self.assertEqual("http://musicbrainz.org/ws/2/collection/898676a6-bc79-4fe2-98ae-79c5940fe1a2/works",
-                         self.m.request_history.pop().url)
+                         self.last_url)
 
         musicbrainzngs.get_events_in_collection("65cb5dda-44aa-44a8-9c0d-4f99a14ab944")
         self.assertEqual("http://musicbrainz.org/ws/2/collection/65cb5dda-44aa-44a8-9c0d-4f99a14ab944/events",
-                         self.m.request_history.pop().url)
+                         self.last_url)
 
         musicbrainzngs.get_places_in_collection("9dde4c3c-520a-4bfd-9aae-446c3a04ce0c")
         self.assertEqual("http://musicbrainz.org/ws/2/collection/9dde4c3c-520a-4bfd-9aae-446c3a04ce0c/places",
-                         self.m.request_history.pop().url)
+                         self.last_url)
 
         musicbrainzngs.get_recordings_in_collection("42bc6dd9-8deb-4bd7-83eb-5dacdb218b38")
         self.assertEqual("http://musicbrainz.org/ws/2/collection/42bc6dd9-8deb-4bd7-83eb-5dacdb218b38/recordings",
-                         self.m.request_history.pop().url)
+                         self.last_url)
 
         musicbrainzngs.get_artists_in_collection("7e582256-b3ce-421f-82ba-451b0ab080eb")
         self.assertEqual("http://musicbrainz.org/ws/2/collection/7e582256-b3ce-421f-82ba-451b0ab080eb/artists",
-                         self.m.request_history.pop().url)
+                         self.last_url)
 
 
 class GetCollectionTest(unittest.TestCase):

--- a/test/test_mbxml_collection.py
+++ b/test/test_mbxml_collection.py
@@ -8,36 +8,44 @@ import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 import musicbrainzngs
 from test import _common
+from re import compile
 
 
-class UrlTest(unittest.TestCase):
+class UrlTest(_common.RequestsMockingTestCase):
     """ Test that the correct URL is generated when a query is made """
 
     def setUp(self):
-        self.opener = _common.FakeOpener("<response/>")
-        musicbrainzngs.compat.build_opener = lambda *args: self.opener
+        super(UrlTest, self).setUp()
 
         musicbrainzngs.set_useragent("test", "1")
         musicbrainzngs.set_rate_limit(False)
 
+        self.m.get(compile("ws/2/.*/.*"), text="<response/>")
+
     def testGetCollection(self):
         musicbrainzngs.get_releases_in_collection("0b15c97c-8eb8-4b4f-81c3-0eb24266a2ac")
-        self.assertEqual("http://musicbrainz.org/ws/2/collection/0b15c97c-8eb8-4b4f-81c3-0eb24266a2ac/releases", self.opener.get_url())
+        self.assertEqual("http://musicbrainz.org/ws/2/collection/0b15c97c-8eb8-4b4f-81c3-0eb24266a2ac/releases",
+                         self.m.request_history.pop().url)
 
         musicbrainzngs.get_works_in_collection("898676a6-bc79-4fe2-98ae-79c5940fe1a2")
-        self.assertEqual("http://musicbrainz.org/ws/2/collection/898676a6-bc79-4fe2-98ae-79c5940fe1a2/works", self.opener.get_url())
+        self.assertEqual("http://musicbrainz.org/ws/2/collection/898676a6-bc79-4fe2-98ae-79c5940fe1a2/works",
+                         self.m.request_history.pop().url)
 
         musicbrainzngs.get_events_in_collection("65cb5dda-44aa-44a8-9c0d-4f99a14ab944")
-        self.assertEqual("http://musicbrainz.org/ws/2/collection/65cb5dda-44aa-44a8-9c0d-4f99a14ab944/events", self.opener.get_url())
+        self.assertEqual("http://musicbrainz.org/ws/2/collection/65cb5dda-44aa-44a8-9c0d-4f99a14ab944/events",
+                         self.m.request_history.pop().url)
 
         musicbrainzngs.get_places_in_collection("9dde4c3c-520a-4bfd-9aae-446c3a04ce0c")
-        self.assertEqual("http://musicbrainz.org/ws/2/collection/9dde4c3c-520a-4bfd-9aae-446c3a04ce0c/places", self.opener.get_url())
+        self.assertEqual("http://musicbrainz.org/ws/2/collection/9dde4c3c-520a-4bfd-9aae-446c3a04ce0c/places",
+                         self.m.request_history.pop().url)
 
         musicbrainzngs.get_recordings_in_collection("42bc6dd9-8deb-4bd7-83eb-5dacdb218b38")
-        self.assertEqual("http://musicbrainz.org/ws/2/collection/42bc6dd9-8deb-4bd7-83eb-5dacdb218b38/recordings", self.opener.get_url())
+        self.assertEqual("http://musicbrainz.org/ws/2/collection/42bc6dd9-8deb-4bd7-83eb-5dacdb218b38/recordings",
+                         self.m.request_history.pop().url)
 
         musicbrainzngs.get_artists_in_collection("7e582256-b3ce-421f-82ba-451b0ab080eb")
-        self.assertEqual("http://musicbrainz.org/ws/2/collection/7e582256-b3ce-421f-82ba-451b0ab080eb/artists", self.opener.get_url())
+        self.assertEqual("http://musicbrainz.org/ws/2/collection/7e582256-b3ce-421f-82ba-451b0ab080eb/artists",
+                         self.m.request_history.pop().url)
 
 
 class GetCollectionTest(unittest.TestCase):

--- a/test/test_mbxml_discid.py
+++ b/test/test_mbxml_discid.py
@@ -7,6 +7,8 @@ import sys
 # of something that's already been installed
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 import musicbrainzngs
+import requests_mock
+from re import compile
 from test import _common
 
 
@@ -14,25 +16,27 @@ class UrlTest(unittest.TestCase):
     """ Test that the correct URL is generated when a search query is made """
 
     def setUp(self):
-        self.opener = _common.FakeOpener("<response/>")
-        musicbrainzngs.compat.build_opener = lambda *args: self.opener
-
         musicbrainzngs.set_useragent("test", "1")
         musicbrainzngs.set_rate_limit(False)
 
-    def testGetDiscId(self):
+    @requests_mock.Mocker()
+    def testGetDiscId(self, m):
+        m.get(compile("musicbrainz.org/ws/2/discid"), text="<response/>")
+
         musicbrainzngs.get_releases_by_discid("xp5tz6rE4OHrBafj0bLfDRMGK48-")
-        self.assertEqual("http://musicbrainz.org/ws/2/discid/xp5tz6rE4OHrBafj0bLfDRMGK48-", self.opener.get_url())
+        self.assertEqual("http://musicbrainz.org/ws/2/discid/xp5tz6rE4OHrBafj0bLfDRMGK48-",
+                         m.request_history.pop().url)
 
         # one include
         musicbrainzngs.get_releases_by_discid("xp5tz6rE4OHrBafj0bLfDRMGK48-",
                 includes=["recordings"])
-        self.assertEqual("http://musicbrainz.org/ws/2/discid/xp5tz6rE4OHrBafj0bLfDRMGK48-?inc=recordings", self.opener.get_url())
+        self.assertEqual("http://musicbrainz.org/ws/2/discid/xp5tz6rE4OHrBafj0bLfDRMGK48-?inc=recordings",
+                         m.request_history.pop().url)
 
         # more than one include
         musicbrainzngs.get_releases_by_discid("xp5tz6rE4OHrBafj0bLfDRMGK48-", includes=["artists", "recordings", "artist-credits"])
         expected = "http://musicbrainz.org/ws/2/discid/xp5tz6rE4OHrBafj0bLfDRMGK48-?inc=artists+recordings+artist-credits"
-        self.assertEqual(expected, self.opener.get_url())
+        self.assertEqual(expected, m.request_history.pop().url)
 
 
 class GetDiscIdTest(unittest.TestCase):

--- a/test/test_mbxml_release.py
+++ b/test/test_mbxml_release.py
@@ -25,18 +25,18 @@ class UrlTest(_common.RequestsMockingTestCase):
     def testGetRelease(self):
         musicbrainzngs.get_release_by_id("5e3524ca-b4a1-4e51-9ba5-63ea2de8f49b")
         self.assertEqual("http://musicbrainz.org/ws/2/release/5e3524ca-b4a1-4e51-9ba5-63ea2de8f49b",
-                         self.m.request_history.pop().url)
+                         self.last_url)
 
         # one include
         musicbrainzngs.get_release_by_id("5e3524ca-b4a1-4e51-9ba5-63ea2de8f49b", includes=["artists"])
         self.assertEqual("http://musicbrainz.org/ws/2/release/5e3524ca-b4a1-4e51-9ba5-63ea2de8f49b?inc=artists",
-                         self.m.request_history.pop().url)
+                         self.last_url)
 
         # more than one include
         musicbrainzngs.get_release_by_id("5e3524ca-b4a1-4e51-9ba5-63ea2de8f49b", includes=["artists", "recordings", "artist-credits"])
         expected = "http://musicbrainz.org/ws/2/release/5e3524ca-b4a1-4e51-9ba5-63ea2de8f49b?inc=artists+recordings+artist-credits"
         self.assertEqual(expected,
-                         self.m.request_history.pop().url)
+                         self.last_url)
 
 
 class GetReleaseTest(unittest.TestCase):

--- a/test/test_mbxml_release.py
+++ b/test/test_mbxml_release.py
@@ -8,30 +8,35 @@ import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 import musicbrainzngs
 from test import _common
+import requests_mock
+from re import compile
 
 
-class UrlTest(unittest.TestCase):
+class UrlTest(_common.RequestsMockingTestCase):
     """ Test that the correct URL is generated when a search query is made """
 
     def setUp(self):
-        self.opener = _common.FakeOpener("<response/>")
-        musicbrainzngs.compat.build_opener = lambda *args: self.opener
+        super(UrlTest, self).setUp()
 
         musicbrainzngs.set_useragent("test", "1")
         musicbrainzngs.set_rate_limit(False)
+        self.m.get(compile("ws/2/.*/.*"), text="<response/>")
 
     def testGetRelease(self):
         musicbrainzngs.get_release_by_id("5e3524ca-b4a1-4e51-9ba5-63ea2de8f49b")
-        self.assertEqual("http://musicbrainz.org/ws/2/release/5e3524ca-b4a1-4e51-9ba5-63ea2de8f49b", self.opener.get_url())
+        self.assertEqual("http://musicbrainz.org/ws/2/release/5e3524ca-b4a1-4e51-9ba5-63ea2de8f49b",
+                         self.m.request_history.pop().url)
 
         # one include
         musicbrainzngs.get_release_by_id("5e3524ca-b4a1-4e51-9ba5-63ea2de8f49b", includes=["artists"])
-        self.assertEqual("http://musicbrainz.org/ws/2/release/5e3524ca-b4a1-4e51-9ba5-63ea2de8f49b?inc=artists", self.opener.get_url())
+        self.assertEqual("http://musicbrainz.org/ws/2/release/5e3524ca-b4a1-4e51-9ba5-63ea2de8f49b?inc=artists",
+                         self.m.request_history.pop().url)
 
         # more than one include
         musicbrainzngs.get_release_by_id("5e3524ca-b4a1-4e51-9ba5-63ea2de8f49b", includes=["artists", "recordings", "artist-credits"])
         expected = "http://musicbrainz.org/ws/2/release/5e3524ca-b4a1-4e51-9ba5-63ea2de8f49b?inc=artists+recordings+artist-credits"
-        self.assertEqual(expected, self.opener.get_url())
+        self.assertEqual(expected,
+                         self.m.request_history.pop().url)
 
 
 class GetReleaseTest(unittest.TestCase):

--- a/test/test_mbxml_search.py
+++ b/test/test_mbxml_search.py
@@ -7,51 +7,62 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 import musicbrainzngs
 from musicbrainzngs import mbxml
 from test import _common
+from re import compile
 
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
 
-class UrlTest(unittest.TestCase):
+
+class UrlTest(_common.RequestsMockingTestCase):
     """ Test that the correct URL is generated when a search query is made """
 
     def setUp(self):
-        self.opener = _common.FakeOpener("<response/>")
-        musicbrainzngs.compat.build_opener = lambda *args: self.opener
+        super(UrlTest, self).setUp()
 
         musicbrainzngs.set_useragent("a", "1")
         musicbrainzngs.set_rate_limit(False)
 
+        self.m.get(compile("ws/2/.*/.*"), text="<response/>")
+
     def testSearchArtist(self):
         musicbrainzngs.search_artists("Dynamo Go")
-        self.assertEqual("http://musicbrainz.org/ws/2/artist/?query=Dynamo+Go", self.opener.get_url())
+        self.assertEqual("http://musicbrainz.org/ws/2/artist/?query=Dynamo+Go",
+                         self.m.request_history.pop().url)
 
     def testSearchEvent(self):
         musicbrainzngs.search_events("woodstock")
-        self.assertEqual("http://musicbrainz.org/ws/2/event/?query=woodstock", self.opener.get_url())
+        self.assertEqual("http://musicbrainz.org/ws/2/event/?query=woodstock",
+                         self.m.request_history.pop().url)
 
     def testSearchLabel(self):
         musicbrainzngs.search_labels("Waysafe")
-        self.assertEqual("http://musicbrainz.org/ws/2/label/?query=Waysafe", self.opener.get_url())
+        self.assertEqual("http://musicbrainz.org/ws/2/label/?query=Waysafe",
+                         self.m.request_history.pop().url)
 
     def testSearchPlace(self):
         musicbrainzngs.search_places("Fillmore")
-        self.assertEqual("http://musicbrainz.org/ws/2/place/?query=Fillmore", self.opener.get_url())
+        self.assertEqual("http://musicbrainz.org/ws/2/place/?query=Fillmore",
+                         self.m.request_history.pop().url)
 
     def testSearchRelease(self):
         musicbrainzngs.search_releases("Affordable Pop Music")
-        self.assertEqual("http://musicbrainz.org/ws/2/release/?query=Affordable+Pop+Music", self.opener.get_url())
+        self.assertEqual("http://musicbrainz.org/ws/2/release/?query=Affordable+Pop+Music",
+                         self.m.request_history.pop().url)
 
     def testSearchReleaseGroup(self):
         musicbrainzngs.search_release_groups("Affordable Pop Music")
-        self.assertEqual("http://musicbrainz.org/ws/2/release-group/?query=Affordable+Pop+Music", self.opener.get_url())
+        self.assertEqual("http://musicbrainz.org/ws/2/release-group/?query=Affordable+Pop+Music",
+                         self.m.request_history.pop().url)
 
     def testSearchRecording(self):
         musicbrainzngs.search_recordings("Thief of Hearts")
-        self.assertEqual("http://musicbrainz.org/ws/2/recording/?query=Thief+of+Hearts", self.opener.get_url())
+        self.assertEqual("http://musicbrainz.org/ws/2/recording/?query=Thief+of+Hearts",
+                         self.m.request_history.pop().url)
 
     def testSearchWork(self):
         musicbrainzngs.search_works("Fountain City")
-        self.assertEqual("http://musicbrainz.org/ws/2/work/?query=Fountain+City", self.opener.get_url())
+        self.assertEqual("http://musicbrainz.org/ws/2/work/?query=Fountain+City",
+                         self.m.request_history.pop().url)
 
 
 class SearchArtistTest(unittest.TestCase):

--- a/test/test_mbxml_search.py
+++ b/test/test_mbxml_search.py
@@ -27,42 +27,42 @@ class UrlTest(_common.RequestsMockingTestCase):
     def testSearchArtist(self):
         musicbrainzngs.search_artists("Dynamo Go")
         self.assertEqual("http://musicbrainz.org/ws/2/artist/?query=Dynamo+Go",
-                         self.m.request_history.pop().url)
+                         self.last_url)
 
     def testSearchEvent(self):
         musicbrainzngs.search_events("woodstock")
         self.assertEqual("http://musicbrainz.org/ws/2/event/?query=woodstock",
-                         self.m.request_history.pop().url)
+                         self.last_url)
 
     def testSearchLabel(self):
         musicbrainzngs.search_labels("Waysafe")
         self.assertEqual("http://musicbrainz.org/ws/2/label/?query=Waysafe",
-                         self.m.request_history.pop().url)
+                         self.last_url)
 
     def testSearchPlace(self):
         musicbrainzngs.search_places("Fillmore")
         self.assertEqual("http://musicbrainz.org/ws/2/place/?query=Fillmore",
-                         self.m.request_history.pop().url)
+                         self.last_url)
 
     def testSearchRelease(self):
         musicbrainzngs.search_releases("Affordable Pop Music")
         self.assertEqual("http://musicbrainz.org/ws/2/release/?query=Affordable+Pop+Music",
-                         self.m.request_history.pop().url)
+                         self.last_url)
 
     def testSearchReleaseGroup(self):
         musicbrainzngs.search_release_groups("Affordable Pop Music")
         self.assertEqual("http://musicbrainz.org/ws/2/release-group/?query=Affordable+Pop+Music",
-                         self.m.request_history.pop().url)
+                         self.last_url)
 
     def testSearchRecording(self):
         musicbrainzngs.search_recordings("Thief of Hearts")
         self.assertEqual("http://musicbrainz.org/ws/2/recording/?query=Thief+of+Hearts",
-                         self.m.request_history.pop().url)
+                         self.last_url)
 
     def testSearchWork(self):
         musicbrainzngs.search_works("Fountain City")
         self.assertEqual("http://musicbrainz.org/ws/2/work/?query=Fountain+City",
-                         self.m.request_history.pop().url)
+                         self.last_url)
 
 
 class SearchArtistTest(unittest.TestCase):

--- a/test/test_requests.py
+++ b/test/test_requests.py
@@ -21,12 +21,12 @@ class ArgumentTest(_common.RequestsMockingTestCase):
     def test_no_client(self):
         musicbrainzngs.set_useragent("testapp", "0.1", "test@example.org")
         musicbrainz._mb_request(path="foo", client_required=False)
-        self.assertFalse("testapp" in self.m.request_history.pop().url)
+        self.assertFalse("testapp" in self.last_url)
 
     def test_client(self):
         musicbrainzngs.set_useragent("testapp", "0.1", "test@example.org")
         musicbrainz._mb_request(path="foo", client_required=True)
-        self.assertTrue("testapp" in self.m.request_history.pop().url)
+        self.assertTrue("testapp" in self.last_url)
 
     def test_false_useragent(self):
         self.assertRaises(ValueError, musicbrainzngs.set_useragent, "", "0.1",

--- a/test/test_requests.py
+++ b/test/test_requests.py
@@ -4,70 +4,69 @@ import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 import musicbrainzngs
 from musicbrainzngs import musicbrainz
+import requests_mock
+from musicbrainzngs import mbxml
+from re import compile
 from test import _common
 
 
-class ArgumentTest(unittest.TestCase):
+class ArgumentTest(_common.RequestsMockingTestCase):
     """Tests request methods to ensure they're enforcing general parameters
     (useragent, authentication)."""
 
     def setUp(self):
-        self.opener = _common.FakeOpener("<response/>")
-        musicbrainzngs.compat.build_opener = lambda *args: self.opener
+        super(ArgumentTest, self).setUp()
+        self.m.get(compile("ws/2/.*"), text="<response/>")
 
     def test_no_client(self):
         musicbrainzngs.set_useragent("testapp", "0.1", "test@example.org")
         musicbrainz._mb_request(path="foo", client_required=False)
-        self.assertFalse("testapp" in self.opener.myurl)
+        self.assertFalse("testapp" in self.m.request_history.pop().url)
 
     def test_client(self):
         musicbrainzngs.set_useragent("testapp", "0.1", "test@example.org")
         musicbrainz._mb_request(path="foo", client_required=True)
-        self.assertTrue("testapp" in self.opener.myurl)
+        self.assertTrue("testapp" in self.m.request_history.pop().url)
 
     def test_false_useragent(self):
         self.assertRaises(ValueError, musicbrainzngs.set_useragent, "", "0.1",
-                "test@example.org")
+                          "test@example.org")
         self.assertRaises(ValueError, musicbrainzngs.set_useragent, "test", "",
-                "test@example.org")
+                          "test@example.org")
 
     def test_missing_auth(self):
-        self.assertRaises(musicbrainzngs.UsageError,
-                musicbrainz._mb_request, path="foo",
-                auth_required=musicbrainz.AUTH_YES)
+        musicbrainz.user = ""
+        self.assertRaises(musicbrainzngs.UsageError, musicbrainz._mb_request,
+                          path="foo", auth_required=musicbrainz.AUTH_YES)
 
     def test_missing_useragent(self):
         musicbrainz._useragent = ""
-        self.assertRaises(musicbrainzngs.UsageError,
-                musicbrainz._mb_request, path="foo")
+        self.assertRaises(musicbrainzngs.UsageError, musicbrainz._mb_request,
+                          path="foo")
 
 
-class MethodTest(unittest.TestCase):
+class MethodTest(_common.RequestsMockingTestCase):
     """Tests the various _do_mb_* methods to ensure they're setting the
     using the correct HTTP method."""
 
     def setUp(self):
-        self.opener = _common.FakeOpener("<response/>")
-        musicbrainzngs.compat.build_opener = lambda *args: self.opener
-
+        super(MethodTest, self).setUp()
         musicbrainz.auth("user", "password")
-
-    def test_invalid_method(self):
-        self.assertRaises(ValueError, musicbrainz._mb_request, path="foo",
-                          method="HUG")
+        self.m.register_uri(requests_mock.ANY, requests_mock.ANY,
+                            text="<response/>")
 
     def test_delete(self):
         musicbrainz._do_mb_delete("foo")
-        self.assertEqual("DELETE", self.opener.request.get_method())
+        self.assertEqual("DELETE", self.m.request_history.pop().method)
 
     def test_put(self):
         musicbrainz._do_mb_put("foo")
-        self.assertEqual("PUT", self.opener.request.get_method())
+        self.assertEqual("PUT", self.m.request_history.pop().method)
 
     def test_post(self):
         musicbrainz._do_mb_post("foo", "body")
-        self.assertEqual("POST", self.opener.request.get_method())
+        self.assertEqual("POST", self.m.request_history.pop().method)
 
     def test_get(self):
         musicbrainz._do_mb_query("artist", 1234, [], [])
-        self.assertEqual("GET", self.opener.request.get_method())
+        self.assertEqual("GET", self.m.request_history.pop().method)

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist=py{26,27,32,33,34,35,py}-requests-{minimum,current}
 [testenv]
 deps=
-    requests-minimum: requests==2.1.0
+    requests-minimum: requests==2.5.0
     requests-current: requests
     requests-mock
 commands=python setup.py test

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,7 @@
 [tox]
 envlist=py26,py27,py32,py33,py34,py35
 [testenv]
+deps=
+    requests
+    requests-mock
 commands=python setup.py test

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
-envlist=py26,py27,py32,py33,py34,py35
+envlist=py{26,27,32,33,34,35,py}-requests-{minimum,current}
 [testenv]
 deps=
-    requests
+    requests-minimum: requests==2.1.0
+    requests-current: requests
     requests-mock
 commands=python setup.py test


### PR DESCRIPTION
This is #123 again, rebased on top of current master and with passing tests :sparkles: 

Note that I've bumped the requests dependency to 2.5.0 because that's the first version that allows using urllib3's Retry objects for max_retries on the HTTPAdapter and (afaik) that's the only way to implement retries on a specific set of HTTP status codes. t

Especially the retry/exception part could use a second pair of eyes to make sure everything works as expected and if you have some scripts that make heavy use of pymbngs, please run them with this pull request and see if nothing breaks.