### PR TITLE
 Convert the CAA response data to unicode before loading it via json

### DIFF
--- a/musicbrainzngs/caa.py
+++ b/musicbrainzngs/caa.py
@@ -13,6 +13,7 @@ import json
 
 from musicbrainzngs import compat
 from musicbrainzngs import musicbrainz
+from musicbrainzngs.util import _unicode
 
 hostname = "coverartarchive.org"
 
@@ -78,7 +79,8 @@ def _caa_request(mbid, imageid=None, size=None, entitytype="release"):
         return resp
     else:
         # Otherwise it's json
-        return json.loads(resp)
+        data = _unicode(resp)
+        return json.loads(data)
 
 
 def get_image_list(releaseid):

--- a/test/_common.py
+++ b/test/_common.py
@@ -2,12 +2,16 @@
 import time
 
 import musicbrainzngs
+from musicbrainzngs import compat
 from os.path import join
 
 try:
     from urllib2 import OpenerDirector
 except ImportError:
     from urllib.request import OpenerDirector
+
+from io import BytesIO
+
 try:
     import StringIO
 except ImportError:
@@ -26,10 +30,14 @@ class FakeOpener(OpenerDirector):
         self.myurl = request.get_full_url()
         self.headers = request.header_items()
         self.request = request
+
         if self.exception:
             raise self.exception
-        else:
+
+        if isinstance(self.response, compat.unicode):
             return StringIO.StringIO(self.response)
+        else:
+            return BytesIO(self.response)
 
     def get_url(self):
         return self.myurl

--- a/test/test_browse.py
+++ b/test/test_browse.py
@@ -10,7 +10,7 @@ from test import _common
 class BrowseTest(unittest.TestCase):
 
     def setUp(self):
-        self.opener = _common.FakeOpener("<response/>")
+        self.opener = _common.FakeOpener()
         musicbrainzngs.compat.build_opener = lambda *args: self.opener
 
         musicbrainzngs.set_useragent("a", "1")

--- a/test/test_caa.py
+++ b/test/test_caa.py
@@ -13,7 +13,7 @@ class CaaTest(unittest.TestCase):
 
     def test_get_list(self):
         # check the url and response for a listing
-        resp = '{"images":[]}'
+        resp = b'{"images":[]}'
         self.opener = _common.FakeOpener(resp)
         musicbrainzngs.compat.build_opener = lambda *args: self.opener
         res = caa.get_image_list("8ec178f4-a8e8-4f22-bcba-1964466ef214")
@@ -23,7 +23,7 @@ class CaaTest(unittest.TestCase):
 
     def test_get_release_group_list(self):
         # check the url and response for a listing
-        resp = '{"images":[], "release": "foo"}'
+        resp = b'{"images":[], "release": "foo"}'
         self.opener = _common.FakeOpener(resp)
         musicbrainzngs.compat.build_opener = lambda *args: self.opener
         res = caa.get_release_group_image_list("8ec178f4-a8e8-4f22-bcba-1964466ef214")
@@ -58,7 +58,7 @@ class CaaTest(unittest.TestCase):
         """ When a useragent is set it is sent with the request """
         musicbrainzngs.set_useragent("caa-test", "0.1")
 
-        resp = '{"images":[]}'
+        resp = b'{"images":[]}'
         self.opener = _common.FakeOpener(resp)
         musicbrainzngs.compat.build_opener = lambda *args: self.opener
         res = caa.get_image_list("8ec178f4-a8e8-4f22-bcba-1964466ef214")
@@ -68,7 +68,7 @@ class CaaTest(unittest.TestCase):
         self.assertEqual("caa-test/0.1 python-musicbrainzngs/%s" % _version, headers["User-agent"])
 
     def test_coverid(self):
-        resp = 'some_image'
+        resp = b'some_image'
         self.opener = _common.FakeOpener(resp)
         musicbrainzngs.compat.build_opener = lambda *args: self.opener
         res = caa.get_image("8ec178f4-a8e8-4f22-bcba-1964466ef214", "1234")
@@ -77,7 +77,7 @@ class CaaTest(unittest.TestCase):
         self.assertEqual(resp, res)
 
     def test_get_size(self):
-        resp = 'some_image'
+        resp = b'some_image'
         self.opener = _common.FakeOpener(resp)
         musicbrainzngs.compat.build_opener = lambda *args: self.opener
         res = caa.get_image("8ec178f4-a8e8-4f22-bcba-1964466ef214", "1234", 250)
@@ -86,7 +86,7 @@ class CaaTest(unittest.TestCase):
         self.assertEqual(resp, res)
 
     def test_front(self):
-        resp = 'front_image'
+        resp = b'front_image'
         self.opener = _common.FakeOpener(resp)
         musicbrainzngs.compat.build_opener = lambda *args: self.opener
         res = caa.get_image_front("8ec178f4-a8e8-4f22-bcba-1964466ef214")
@@ -95,7 +95,7 @@ class CaaTest(unittest.TestCase):
         self.assertEqual(resp, res)
 
     def test_release_group_front(self):
-        resp = 'front_image'
+        resp = b'front_image'
         self.opener = _common.FakeOpener(resp)
         musicbrainzngs.compat.build_opener = lambda *args: self.opener
         res = caa.get_release_group_image_front("8ec178f4-a8e8-4f22-bcba-1964466ef214")
@@ -104,7 +104,7 @@ class CaaTest(unittest.TestCase):
         self.assertEqual(resp, res)
 
     def test_back(self):
-        resp = 'back_image'
+        resp = b'back_image'
         self.opener = _common.FakeOpener(resp)
         musicbrainzngs.compat.build_opener = lambda *args: self.opener
         res = caa.get_image_back("8ec178f4-a8e8-4f22-bcba-1964466ef214")


### PR DESCRIPTION
HTTPResponse.read() always returns bytes, but json.loads expects a
str (or unicode) object. On Python 2, this conversion happened
automatically, on Python 3, it didn't, so do it explicitly.

Fixes #208.

Signed-off-by: Wieland Hoffmann <themineo@gmail.com>