### PR TITLE
Fix independent test running (#211)

### DIFF
--- a/musicbrainzngs/compat.py
+++ b/musicbrainzngs/compat.py
@@ -40,8 +40,7 @@ is_py3 = (_ver[0] == 3)
 if is_py2:
 	from StringIO import StringIO
 	from urllib2 import HTTPPasswordMgr, HTTPDigestAuthHandler, Request,\
-						HTTPHandler, build_opener, HTTPError, URLError,\
-						build_opener
+						HTTPHandler, build_opener, HTTPError, URLError
 	from httplib import BadStatusLine, HTTPException
 	from urlparse import urlunparse
 	from urllib import urlencode

--- a/test/test_requests.py
+++ b/test/test_requests.py
@@ -14,6 +14,11 @@ class ArgumentTest(unittest.TestCase):
     def setUp(self):
         self.opener = _common.FakeOpener("<response/>")
         musicbrainzngs.compat.build_opener = lambda *args: self.opener
+        self.orig_do_rate_limit = musicbrainz.do_rate_limit
+        musicbrainz.do_rate_limit = False
+
+    def tearDown(self):
+        musicbrainz.do_rate_limit = self.orig_do_rate_limit
 
     def test_no_client(self):
         musicbrainzngs.set_useragent("testapp", "0.1", "test@example.org")

--- a/test/test_submit.py
+++ b/test/test_submit.py
@@ -8,6 +8,19 @@ from musicbrainzngs import musicbrainz
 from test import _common
 
 class SubmitTest(unittest.TestCase):
+
+    def setUp(self):
+        self.orig_opener = musicbrainzngs.compat.build_opener
+        musicbrainz.set_useragent("test_client", "1.0")
+        musicbrainz.auth("user", "password")
+
+    def tearDown(self):
+        musicbrainzngs.compat.build_opener = self.orig_opener
+        musicbrainz._useragent = ""
+        musicbrainz._client = ""
+        musicbrainz.user = ""
+        musicbrainz.password = ""
+
     def test_submit_tags(self):
         self.opener = _common.FakeOpener("<response/>")
         musicbrainzngs.compat.build_opener = lambda *args: self.opener


### PR DESCRIPTION
Fixes #211
Now tests work when run independently.

I thought about adding a parent testcase class which set client/auth in the `setUp` and back to empty in `tearDown`, but I wasn't sure if it was a good idea to do it in all tests even if they didn't use that functionality.
(Also, how do you do `super` compatible with python2 and python3?)