### PR TITLE
add "work-level-rels" support for recording lookup

### DIFF
--- a/musicbrainzngs/musicbrainz.py
+++ b/musicbrainzngs/musicbrainz.py
@@ -54,7 +54,7 @@ VALID_INCLUDES = {
     'recording': [
         "artists", "releases", # Subqueries
         "discids", "media", "artist-credits", "isrcs",
-        "annotation", "aliases"
+        "work-level-rels", "annotation", "aliases"
     ] + TAG_INCLUDES + RATING_INCLUDES + RELATION_INCLUDES,
     'release': [
         "artists", "labels", "recordings", "release-groups", "media",


### PR DESCRIPTION
musicbrainz support "work-level-rels" for recording since 2011-10-10
Reference: https://tickets.metabrainz.org/browse/MBS-3223