### PR TITLE
Change import statements to use relative paths

### DIFF
--- a/musicbrainzngs/__init__.py
+++ b/musicbrainzngs/__init__.py
@@ -1,2 +1,2 @@
-from musicbrainzngs.musicbrainz import *
-from musicbrainzngs.caa import *
+from .musicbrainz import *
+from .caa import *

--- a/musicbrainzngs/caa.py
+++ b/musicbrainzngs/caa.py
@@ -11,9 +11,9 @@ __all__ = [
 
 import json
 
-from musicbrainzngs import compat
-from musicbrainzngs import musicbrainz
-from musicbrainzngs.util import _unicode
+from . import compat
+from . import musicbrainz
+from .util import _unicode
 
 hostname = "coverartarchive.org"
 

--- a/musicbrainzngs/mbxml.py
+++ b/musicbrainzngs/mbxml.py
@@ -7,7 +7,7 @@ import re
 import xml.etree.ElementTree as ET
 import logging
 
-from musicbrainzngs import util
+from . import util
 
 try:
     from ET import fixtag

--- a/musicbrainzngs/musicbrainz.py
+++ b/musicbrainzngs/musicbrainz.py
@@ -16,9 +16,9 @@ import xml.etree.ElementTree as etree
 from xml.parsers import expat
 from warnings import warn
 
-from musicbrainzngs import mbxml
-from musicbrainzngs import util
-from musicbrainzngs import compat
+from . import mbxml
+from . import util
+from . import compat
 
 _version = "0.7dev"
 _log = logging.getLogger("musicbrainzngs")


### PR DESCRIPTION
This allows the package to be imported successfully when it's not in PATH or the current directory. For example:

```python
from resources.lib import musicbrainzngs
```