### PR TITLE
Add work-rels as an include for recordings

### DIFF
--- a/musicbrainzngs/musicbrainz.py
+++ b/musicbrainzngs/musicbrainz.py
@@ -54,7 +54,7 @@ VALID_INCLUDES = {
     'recording': [
         "artists", "releases", # Subqueries
         "discids", "media", "artist-credits", "isrcs",
-        "work-level-rels", "annotation", "aliases"
+        "work-level-rels", "annotation", "aliases", "work-rels"
     ] + TAG_INCLUDES + RATING_INCLUDES + RELATION_INCLUDES,
     'release': [
         "artists", "labels", "recordings", "release-groups", "media",


### PR DESCRIPTION
In order to find a work id for an individual track (as opposed to a release) I think this update is needed.