### PR TITLE
Remove `artists` as a valid include to get_work

### DIFF
--- a/musicbrainzngs/musicbrainz.py
+++ b/musicbrainzngs/musicbrainz.py
@@ -69,7 +69,6 @@ VALID_INCLUDES = {
         "annotation", "aliases"
     ] + RELATION_INCLUDES,
     'work': [
-        "artists", # Subqueries
         "aliases", "annotation"
     ] + TAG_INCLUDES + RATING_INCLUDES + RELATION_INCLUDES,
     'url': RELATION_INCLUDES,


### PR DESCRIPTION
This used to be a valid include in the musicbrainz server but was removed in https://github.com/metabrainz/musicbrainz-server/commit/f894001cdcb8a
Fixes #227