### PR TITLE
Drop old python versions and add new ones

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
-  - "3.2"
-  - "3.3"
+  - "3.4"
+  - "3.5"
+  - "3.6"
+  - "3.7"
   - "pypy"
 install: python setup.py build
 script: python setup.py test

--- a/musicbrainzngs/mbxml.py
+++ b/musicbrainzngs/mbxml.py
@@ -7,29 +7,26 @@ import re
 import xml.etree.ElementTree as ET
 import logging
 
-from musicbrainzngs import util
+from . import util
 
-try:
-    from ET import fixtag
-except:
-    # Python < 2.7
-    def fixtag(tag, namespaces):
-        # given a decorated tag (of the form {uri}tag), return prefixed
-        # tag and namespace declaration, if any
-        if isinstance(tag, ET.QName):
-            tag = tag.text
-        namespace_uri, tag = tag[1:].split("}", 1)
-        prefix = namespaces.get(namespace_uri)
-        if prefix is None:
-            prefix = "ns%d" % len(namespaces)
-            namespaces[namespace_uri] = prefix
-            if prefix == "xml":
-                xmlns = None
-            else:
-                xmlns = ("xmlns:%s" % prefix, namespace_uri)
-        else:
+
+def fixtag(tag, namespaces):
+    # given a decorated tag (of the form {uri}tag), return prefixed
+    # tag and namespace declaration, if any
+    if isinstance(tag, ET.QName):
+        tag = tag.text
+    namespace_uri, tag = tag[1:].split("}", 1)
+    prefix = namespaces.get(namespace_uri)
+    if prefix is None:
+        prefix = "ns%d" % len(namespaces)
+        namespaces[namespace_uri] = prefix
+        if prefix == "xml":
             xmlns = None
-        return "%s:%s" % (prefix, tag), xmlns
+        else:
+            xmlns = ("xmlns:%s" % prefix, namespace_uri)
+    else:
+        xmlns = None
+    return "%s:%s" % (prefix, tag), xmlns
 
 
 NS_MAP = {"http://musicbrainz.org/ns/mmd-2.0#": "ws2",

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,4 @@
 [tox]
-envlist=py27,py34,py35,py36
+envlist=py27,py34,py35,py36,py37
 [testenv]
 commands=python setup.py test

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,4 @@
 [tox]
-envlist=py26,py27,py32,py33,py34,py35,py36
+envlist=py27,py34,py35,py36
 [testenv]
 commands=python setup.py test


### PR DESCRIPTION
* Add support for python 3.7 to tox tests
* Remove support for python 2.6, 3.2, 3.3 from tox tests
* Improve the way we define `mbxml.fixtag`

Rationale for removing old versions of python:
According to Python PEPs for each major version, each of 2.6, 3.2, and 3.3 have reached end of life:
 * https://www.python.org/dev/peps/pep-0361/#release-lifespan
 * https://www.python.org/dev/peps/pep-0392/#lifespan
 * https://www.python.org/dev/peps/pep-0398/#lifespan

Additionally, other large projects like Django and Requests only support 3.4 and up.
Recent versions of pip have a vendored version of requests, which means that some features break on python 3.2 (for example `u''` strings)

Debian oldstable (released 2015-04) and Ubuntu Trusty (14.04 LTS, released 2014) both have python 3.4 as default versions, so I don't see strong reasons to support lower.

Of course, this is only dropping support in official tests, I don't think we will be introducing code that doesn't run on these removed versions any time soon.