### PR TITLE
Don't add the parent directory to sys.path in each test

### DIFF
--- a/test/test_browse.py
+++ b/test/test_browse.py
@@ -1,11 +1,8 @@
 import unittest
-import os
-import sys
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 import musicbrainzngs
-from musicbrainzngs import musicbrainz
 from test import _common
+
 
 class BrowseTest(unittest.TestCase):
 

--- a/test/test_caa.py
+++ b/test/test_caa.py
@@ -1,13 +1,11 @@
 import unittest
-import os
-import sys
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from musicbrainzngs import caa
 from musicbrainzngs import compat
 from musicbrainzngs.musicbrainz import _version
 import musicbrainzngs
 from test import _common
+
 
 class CaaTest(unittest.TestCase):
 

--- a/test/test_collection.py
+++ b/test/test_collection.py
@@ -1,12 +1,8 @@
 import unittest
-import os
-import sys
-# Insert .. at the beginning of path so we use this version instead
-# of something that's already been installed
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 import musicbrainzngs
 from musicbrainzngs import compat
 from test import _common
+
 
 class CollectionTest(unittest.TestCase):
     """ Test that requesting collections works properly """

--- a/test/test_getentity.py
+++ b/test/test_getentity.py
@@ -1,9 +1,4 @@
 import unittest
-import os
-import sys
-# Insert .. at the beginning of path so we use this version instead
-# of something that's already been installed
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 import musicbrainzngs
 from test import _common
 

--- a/test/test_mbxml.py
+++ b/test/test_mbxml.py
@@ -1,8 +1,6 @@
 import unittest
-import os
-import sys
-sys.path.append(os.path.abspath(".."))
 from musicbrainzngs import mbxml
+
 
 class MbXML(unittest.TestCase):
 

--- a/test/test_mbxml_artist.py
+++ b/test/test_mbxml_artist.py
@@ -2,11 +2,8 @@
 
 import unittest
 import os
-import sys
-# Insert .. at the beginning of path so we use this version instead
-# of something that's already been installed
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from test import _common
+
 
 class GetArtistTest(unittest.TestCase):
     def setUp(self):

--- a/test/test_mbxml_collection.py
+++ b/test/test_mbxml_collection.py
@@ -2,10 +2,6 @@
 
 import unittest
 import os
-import sys
-# Insert .. at the beginning of path so we use this version instead
-# of something that's already been installed
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 import musicbrainzngs
 from test import _common
 

--- a/test/test_mbxml_discid.py
+++ b/test/test_mbxml_discid.py
@@ -2,10 +2,6 @@
 
 import unittest
 import os
-import sys
-# Insert .. at the beginning of path so we use this version instead
-# of something that's already been installed
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 import musicbrainzngs
 from test import _common
 

--- a/test/test_mbxml_event.py
+++ b/test/test_mbxml_event.py
@@ -2,10 +2,6 @@
 
 import unittest
 import os
-import sys
-# Insert .. at the beginning of path so we use this version instead
-# of something that's already been installed
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from test import _common
 
 

--- a/test/test_mbxml_instrument.py
+++ b/test/test_mbxml_instrument.py
@@ -3,12 +3,8 @@
 
 import unittest
 import os
-import sys
-# Insert .. at the beginning of path so we use this version instead
-# of something that's already been installed
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from test import _common
-import musicbrainzngs
+
 
 class GetInstrumentTest(unittest.TestCase):
     def setUp(self):

--- a/test/test_mbxml_label.py
+++ b/test/test_mbxml_label.py
@@ -2,11 +2,8 @@
 
 import unittest
 import os
-import sys
-# Insert .. at the beginning of path so we use this version instead
-# of something that's already been installed
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from test import _common
+
 
 class GetLabelTest(unittest.TestCase):
     def setUp(self):

--- a/test/test_mbxml_place.py
+++ b/test/test_mbxml_place.py
@@ -2,10 +2,6 @@
 
 import unittest
 import os
-import sys
-# Insert .. at the beginning of path so we use this version instead
-# of something that's already been installed
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from test import _common
 
 

--- a/test/test_mbxml_recording.py
+++ b/test/test_mbxml_recording.py
@@ -3,11 +3,8 @@
 
 import unittest
 import os
-import sys
-# Insert .. at the beginning of path so we use this version instead
-# of something that's already been installed
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from test import _common
+
 
 class GetRecordingTest(unittest.TestCase):
     def setUp(self):

--- a/test/test_mbxml_release.py
+++ b/test/test_mbxml_release.py
@@ -2,10 +2,6 @@
 
 import unittest
 import os
-import sys
-# Insert .. at the beginning of path so we use this version instead
-# of something that's already been installed
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 import musicbrainzngs
 from test import _common
 

--- a/test/test_mbxml_release_group.py
+++ b/test/test_mbxml_release_group.py
@@ -2,10 +2,6 @@
 
 import unittest
 import os
-import sys
-# Insert .. at the beginning of path so we use this version instead
-# of something that's already been installed
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from test import _common
 
 

--- a/test/test_mbxml_search.py
+++ b/test/test_mbxml_search.py
@@ -1,15 +1,12 @@
 import unittest
 import os
-import sys
-# Insert .. at the beginning of path so we use this version instead
-# of something that's already been installed
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 import musicbrainzngs
 from musicbrainzngs import mbxml
 from test import _common
 
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
+
 
 class UrlTest(unittest.TestCase):
     """ Test that the correct URL is generated when a search query is made """

--- a/test/test_mbxml_work.py
+++ b/test/test_mbxml_work.py
@@ -3,11 +3,8 @@
 
 import unittest
 import os
-import sys
-# Insert .. at the beginning of path so we use this version instead
-# of something that's already been installed
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from test import _common
+
 
 class GetWorkTest(unittest.TestCase):
     def setUp(self):

--- a/test/test_ratelimit.py
+++ b/test/test_ratelimit.py
@@ -1,8 +1,5 @@
 import unittest
-import os
-import sys
 import time
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 import musicbrainzngs
 from musicbrainzngs import musicbrainz
 from test._common import Timecop

--- a/test/test_requests.py
+++ b/test/test_requests.py
@@ -1,7 +1,4 @@
 import unittest
-import os
-import sys
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 import musicbrainzngs
 from musicbrainzngs import musicbrainz
 from test import _common

--- a/test/test_submit.py
+++ b/test/test_submit.py
@@ -1,11 +1,8 @@
 import unittest
-import os
-import sys
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 import musicbrainzngs
 from musicbrainzngs import musicbrainz
 from test import _common
+
 
 class SubmitTest(unittest.TestCase):
 


### PR DESCRIPTION
When running tests from the main directory with python setup.py test
or with a test runner, the current directory is already at the
beginning of sys.path, so there is no need to insert it. By inserting
it in every file we were ending up with this directory in sys.path
20 times.