### PR TITLE
Add missing valid seach parameters

### DIFF
--- a/musicbrainzngs/compat.py
+++ b/musicbrainzngs/compat.py
@@ -43,7 +43,7 @@ if is_py2:
 						HTTPHandler, build_opener, HTTPError, URLError
 	from httplib import BadStatusLine, HTTPException
 	from urlparse import urlunparse
-	from urllib import urlencode
+	from urllib import urlencode, quote_plus
 
 	bytes = str
 	unicode = unicode
@@ -54,7 +54,7 @@ elif is_py3:
 								HTTPHandler, build_opener
 	from urllib.error import HTTPError, URLError
 	from http.client import HTTPException, BadStatusLine
-	from urllib.parse import urlunparse, urlencode
+	from urllib.parse import urlunparse, urlencode, quote_plus
 
 	unicode = str
 	bytes = bytes

--- a/musicbrainzngs/musicbrainz.py
+++ b/musicbrainzngs/musicbrainz.py
@@ -109,25 +109,37 @@ VALID_SEARCH_FIELDS = {
     ],
     'area': [
         'aid', 'area', 'alias', 'begin', 'comment', 'end', 'ended',
-        'iso', 'iso1', 'iso2', 'iso3', 'type'
+        'iso', 'iso1', 'iso2', 'iso3', 'sortname', 'type'
     ],
     'artist': [
         'arid', 'artist', 'artistaccent', 'alias', 'begin', 'comment',
         'country', 'end', 'ended', 'gender', 'ipi', 'sortname', 'tag', 'type',
         'area', 'beginarea', 'endarea'
     ],
+    'event': [
+        'alias', 'aid', 'area', 'arid', 'artist', 'comment', 'eid', 'event',
+        'pid', 'place', 'type', 'tag'
+    ],
+    'instrument': [
+        'alias', 'comment', 'description', 'iid', 'instrument',
+        'type', 'tag'
+    ],
     'label': [
         'alias', 'begin', 'code', 'comment', 'country', 'end', 'ended',
         'ipi', 'label', 'labelaccent', 'laid', 'sortname', 'type', 'tag',
         'area'
+    ],
+    'place': [
+        'pid', 'address', 'alias', 'area', 'begin', 'comment', 'end', 'ended',
+        'lat', 'long', 'place', 'placeaccent', 'type'
     ],
     'recording': [
         'arid', 'artist', 'artistname', 'creditname', 'comment',
         'country', 'date', 'dur', 'format', 'isrc', 'number',
         'position', 'primarytype', 'qdur', 'recording',
         'recordingaccent', 'reid', 'release', 'rgid', 'rid',
-        'secondarytype', 'status', 'tnum', 'tracks', 'tracksrelease',
-        'tag', 'type', 'video'
+        'secondarytype', 'status', 'tid', 'tnum', 'tracks',
+        'tracksrelease', 'tag', 'type', 'video'
     ],
     'release-group': [
         'arid', 'artist', 'artistname', 'comment', 'creditname',
@@ -144,7 +156,7 @@ VALID_SEARCH_FIELDS = {
         'tracksmedium', 'type'
     ],
     'series': [
-        'alias', 'comment', 'sid', 'series', 'type'
+        'alias', 'comment', 'sid', 'series', 'type', 'tag'
     ],
     'work': [
         'alias', 'arid', 'artist', 'comment', 'iswc', 'lang', 'tag',

--- a/musicbrainzngs/musicbrainz.py
+++ b/musicbrainzngs/musicbrainz.py
@@ -108,60 +108,58 @@ VALID_SEARCH_FIELDS = {
         'entity', 'name', 'text', 'type'
     ],
     'area': [
-        'aid', 'area', 'alias', 'begin', 'comment', 'end', 'ended',
-        'iso', 'iso1', 'iso2', 'iso3', 'sortname', 'type'
+        'aid', 'alias', 'area', 'areaaccent', 'begin', 'comment', 'end',
+        'ended', 'iso', 'iso1', 'iso2', 'iso3', 'sortname', 'tag', 'type'
     ],
     'artist': [
-        'arid', 'artist', 'artistaccent', 'alias', 'begin', 'comment',
-        'country', 'end', 'ended', 'gender', 'ipi', 'sortname', 'tag', 'type',
-        'area', 'beginarea', 'endarea'
+        'alias', 'area', 'arid', 'artist', 'artistaccent', 'begin', 'beginarea',
+        'comment', 'country', 'end', 'endarea', 'ended', 'gender',
+        'ipi', 'isni', 'primary_alias', 'sortname', 'tag', 'type'
     ],
     'event': [
-        'alias', 'aid', 'area', 'arid', 'artist', 'comment', 'eid', 'event',
-        'pid', 'place', 'type', 'tag'
+        'aid', 'alias', 'area', 'arid', 'artist', 'begin', 'comment', 'eid',
+        'end', 'ended', 'event', 'eventaccent', 'pid', 'place', 'tag', 'type'
     ],
     'instrument': [
         'alias', 'comment', 'description', 'iid', 'instrument',
-        'type', 'tag'
+        'instrumentaccent', 'tag', 'type'
     ],
     'label': [
-        'alias', 'begin', 'code', 'comment', 'country', 'end', 'ended',
-        'ipi', 'label', 'labelaccent', 'laid', 'sortname', 'type', 'tag',
-        'area'
-    ],
-    'place': [
-        'pid', 'address', 'alias', 'area', 'begin', 'comment', 'end', 'ended',
-        'lat', 'long', 'place', 'placeaccent', 'type'
-    ],
-    'recording': [
-        'arid', 'artist', 'artistname', 'creditname', 'comment',
-        'country', 'date', 'dur', 'format', 'isrc', 'number',
-        'position', 'primarytype', 'qdur', 'recording',
-        'recordingaccent', 'reid', 'release', 'rgid', 'rid',
-        'secondarytype', 'status', 'tid', 'tnum', 'tracks',
-        'tracksrelease', 'tag', 'type', 'video'
-    ],
-    'release-group': [
-        'arid', 'artist', 'artistname', 'comment', 'creditname',
-        'primarytype', 'rgid', 'releasegroup', 'releasegroupaccent',
-        'releases', 'release', 'reid', 'secondarytype', 'status',
+        'alias', 'area', 'begin', 'code', 'comment', 'country', 'end', 'ended',
+        'ipi', 'label', 'labelaccent', 'laid', 'release_count', 'sortname',
         'tag', 'type'
     ],
+    'place': [
+        'address', 'alias', 'area', 'begin', 'comment', 'end', 'ended', 'lat', 'long',
+        'pid', 'place', 'placeaccent', 'type'
+    ],
+    'recording': [
+        'alias', 'arid', 'artist', 'artistname', 'comment', 'country',
+        'creditname', 'date', 'dur', 'format', 'isrc', 'number', 'position',
+        'primarytype', 'qdur', 'recording', 'recordingaccent', 'reid',
+        'release', 'rgid', 'rid', 'secondarytype', 'status', 'tag', 'tid',
+        'tnum', 'tracks', 'tracksrelease', 'type', 'video'],
+
+    'release-group': [
+        'alias', 'arid', 'artist', 'artistname', 'comment', 'creditname',
+        'primarytype', 'reid', 'release', 'releasegroup', 'releasegroupaccent',
+        'releases', 'rgid', 'secondarytype', 'status', 'tag', 'type'
+    ],
     'release': [
-        'arid', 'artist', 'artistname', 'asin', 'barcode', 'creditname',
-        'catno', 'comment', 'country', 'creditname', 'date', 'discids',
-        'discidsmedium', 'format', 'laid', 'label', 'lang', 'mediums',
-        'primarytype', 'quality', 'reid', 'release', 'releaseaccent',
-        'rgid', 'script', 'secondarytype', 'status', 'tag', 'tracks',
-        'tracksmedium', 'type'
+        'alias', 'arid', 'artist', 'artistname', 'asin', 'barcode', 'catno',
+        'comment', 'country', 'creditname', 'date', 'discids', 'discidsmedium',
+        'format', 'label', 'laid', 'lang', 'mediums', 'primarytype', 'quality',
+        'reid', 'release', 'releaseaccent', 'rgid', 'script', 'secondarytype',
+        'status', 'tag', 'tracks', 'tracksmedium', 'type'
     ],
     'series': [
-        'alias', 'comment', 'sid', 'series', 'type', 'tag'
+        'alias', 'comment', 'orderingattribute', 'series', 'seriesaccent',
+        'sid', 'tag', 'type'
     ],
     'work': [
-        'alias', 'arid', 'artist', 'comment', 'iswc', 'lang', 'tag',
-        'type', 'wid', 'work', 'workaccent'
-    ],
+        'alias', 'arid', 'artist', 'comment', 'iswc', 'lang', 'recording',
+        'recording_count', 'rid', 'tag', 'type', 'wid', 'work', 'workaccent'
+    ]
 }
 
 # Constants

--- a/test/test_mbxml_search.py
+++ b/test/test_mbxml_search.py
@@ -1,54 +1,9 @@
 import unittest
 import os
-import musicbrainzngs
 from musicbrainzngs import mbxml
-from test import _common
 
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
-
-
-class UrlTest(unittest.TestCase):
-    """ Test that the correct URL is generated when a search query is made """
-
-    def setUp(self):
-        self.opener = _common.FakeOpener("<response/>")
-        musicbrainzngs.compat.build_opener = lambda *args: self.opener
-
-        musicbrainzngs.set_useragent("a", "1")
-        musicbrainzngs.set_rate_limit(False)
-
-    def testSearchArtist(self):
-        musicbrainzngs.search_artists("Dynamo Go")
-        self.assertEqual("http://musicbrainz.org/ws/2/artist/?query=Dynamo+Go", self.opener.get_url())
-
-    def testSearchEvent(self):
-        musicbrainzngs.search_events("woodstock")
-        self.assertEqual("http://musicbrainz.org/ws/2/event/?query=woodstock", self.opener.get_url())
-
-    def testSearchLabel(self):
-        musicbrainzngs.search_labels("Waysafe")
-        self.assertEqual("http://musicbrainz.org/ws/2/label/?query=Waysafe", self.opener.get_url())
-
-    def testSearchPlace(self):
-        musicbrainzngs.search_places("Fillmore")
-        self.assertEqual("http://musicbrainz.org/ws/2/place/?query=Fillmore", self.opener.get_url())
-
-    def testSearchRelease(self):
-        musicbrainzngs.search_releases("Affordable Pop Music")
-        self.assertEqual("http://musicbrainz.org/ws/2/release/?query=Affordable+Pop+Music", self.opener.get_url())
-
-    def testSearchReleaseGroup(self):
-        musicbrainzngs.search_release_groups("Affordable Pop Music")
-        self.assertEqual("http://musicbrainz.org/ws/2/release-group/?query=Affordable+Pop+Music", self.opener.get_url())
-
-    def testSearchRecording(self):
-        musicbrainzngs.search_recordings("Thief of Hearts")
-        self.assertEqual("http://musicbrainz.org/ws/2/recording/?query=Thief+of+Hearts", self.opener.get_url())
-
-    def testSearchWork(self):
-        musicbrainzngs.search_works("Fountain City")
-        self.assertEqual("http://musicbrainz.org/ws/2/work/?query=Fountain+City", self.opener.get_url())
 
 
 class SearchArtistTest(unittest.TestCase):
@@ -63,6 +18,7 @@ class SearchArtistTest(unittest.TestCase):
         # Score is a key that is only in search results -
         # so check for it here
         self.assertEqual("100", one["ext:score"])
+
 
 class SearchReleaseTest(unittest.TestCase):
     def testFields(self):
@@ -79,6 +35,7 @@ class SearchReleaseTest(unittest.TestCase):
         self.assertEqual(1, one["medium-count"])
         self.assertEqual("CD", one["medium-list"][0]["format"])
 
+
 class SearchReleaseGroupTest(unittest.TestCase):
     def testFields(self):
         fn = os.path.join(DATA_DIR, "search-release-group.xml")
@@ -88,6 +45,7 @@ class SearchReleaseGroupTest(unittest.TestCase):
         self.assertEqual(14641, res["release-group-count"])
         one = res["release-group-list"][0]
         self.assertEqual("100", one["ext:score"])
+
 
 class SearchWorkTest(unittest.TestCase):
     def testFields(self):
@@ -99,6 +57,7 @@ class SearchWorkTest(unittest.TestCase):
         one = res["work-list"][0]
         self.assertEqual("100", one["ext:score"])
 
+
 class SearchLabelTest(unittest.TestCase):
     def testFields(self):
         fn = os.path.join(DATA_DIR, "search-label.xml")
@@ -109,6 +68,7 @@ class SearchLabelTest(unittest.TestCase):
         one = res["label-list"][0]
         self.assertEqual("100", one["ext:score"])
 
+
 class SearchRecordingTest(unittest.TestCase):
     def testFields(self):
         fn = os.path.join(DATA_DIR, "search-recording.xml")
@@ -118,6 +78,7 @@ class SearchRecordingTest(unittest.TestCase):
         self.assertEqual(1258, res["recording-count"])
         one = res["recording-list"][0]
         self.assertEqual("100", one["ext:score"])
+
 
 class SearchInstrumentTest(unittest.TestCase):
     def testFields(self):
@@ -131,6 +92,7 @@ class SearchInstrumentTest(unittest.TestCase):
         end = res["instrument-list"][-1]
         self.assertEqual("29", end["ext:score"])
 
+
 class SearchPlaceTest(unittest.TestCase):
     def testFields(self):
         fn = os.path.join(DATA_DIR, "search-place.xml")
@@ -143,6 +105,7 @@ class SearchPlaceTest(unittest.TestCase):
         two = res["place-list"][1]
         self.assertEqual("63", two["ext:score"])
         self.assertEqual("Southampton", two["disambiguation"])
+
 
 class SearchEventTest(unittest.TestCase):
     def testFields(self):

--- a/test/test_search.py
+++ b/test/test_search.py
@@ -1,0 +1,135 @@
+import unittest
+
+import musicbrainzngs
+from test import _common
+
+
+class SearchUrlTest(unittest.TestCase):
+    """ Test that the correct URL is generated when a search query is made """
+
+    def setUp(self):
+        self.opener = _common.FakeOpener("<response/>")
+        musicbrainzngs.compat.build_opener = lambda *args: self.opener
+
+        musicbrainzngs.set_useragent("a", "1")
+        musicbrainzngs.set_rate_limit(False)
+
+    def test_search_annotations(self):
+        musicbrainzngs.search_annotations("Pieds")
+        self.assertEquals("http://musicbrainz.org/ws/2/annotation/?query=Pieds", self.opener.get_url())
+
+        # Query fields
+        musicbrainzngs.search_annotations(entity="bdb24cb5-404b-4f60-bba4-7b730325ae47")
+        # TODO: We escape special characters and then urlencode all query parameters, which may
+        # not be necessary, but MusicBrainz accepts it and appears to return the same value as without
+        expected_query = 'entity:(bdb24cb5\-404b\-4f60\-bba4\-7b730325ae47)'
+        expected = 'http://musicbrainz.org/ws/2/annotation/?query=%s' % musicbrainzngs.compat.quote_plus(expected_query)
+        self.assertEquals(expected, self.opener.get_url())
+
+        # Invalid query field
+        with self.assertRaises(musicbrainzngs.InvalidSearchFieldError):
+            musicbrainzngs.search_annotations(foo="value")
+
+    def test_search_artists(self):
+        musicbrainzngs.search_artists("Dynamo Go")
+        self.assertEqual("http://musicbrainz.org/ws/2/artist/?query=Dynamo+Go", self.opener.get_url())
+
+        musicbrainzngs.search_artists(artist="Dynamo Go")
+        expected_query = 'artist:(dynamo go)'
+        expected = 'http://musicbrainz.org/ws/2/artist/?query=%s' % musicbrainzngs.compat.quote_plus(expected_query)
+        self.assertEquals(expected, self.opener.get_url())
+
+        # Invalid query field
+        with self.assertRaises(musicbrainzngs.InvalidSearchFieldError):
+            musicbrainzngs.search_artists(foo="value")
+
+    def test_search_events(self):
+        musicbrainzngs.search_events("woodstock")
+        self.assertEqual("http://musicbrainz.org/ws/2/event/?query=woodstock", self.opener.get_url())
+
+        musicbrainzngs.search_events(event="woodstock")
+        expected_query = 'event:(woodstock)'
+        expected = 'http://musicbrainz.org/ws/2/event/?query=%s' % musicbrainzngs.compat.quote_plus(expected_query)
+        self.assertEquals(expected, self.opener.get_url())
+
+        # Invalid query field
+        with self.assertRaises(musicbrainzngs.InvalidSearchFieldError):
+            musicbrainzngs.search_events(foo="value")
+
+    def test_search_labels(self):
+        musicbrainzngs.search_labels("Waysafe")
+        self.assertEqual("http://musicbrainz.org/ws/2/label/?query=Waysafe", self.opener.get_url())
+
+        musicbrainzngs.search_labels(label="Waysafe")
+        expected_query = 'label:(waysafe)'
+        expected = 'http://musicbrainz.org/ws/2/label/?query=%s' % musicbrainzngs.compat.quote_plus(expected_query)
+        self.assertEquals(expected, self.opener.get_url())
+
+        # Invalid query field
+        with self.assertRaises(musicbrainzngs.InvalidSearchFieldError):
+            musicbrainzngs.search_labels(foo="value")
+
+    def test_search_places(self):
+        musicbrainzngs.search_places("Fillmore")
+        self.assertEqual("http://musicbrainz.org/ws/2/place/?query=Fillmore", self.opener.get_url())
+
+        musicbrainzngs.search_places(place="Fillmore")
+        expected_query = 'place:(fillmore)'
+        expected = 'http://musicbrainz.org/ws/2/place/?query=%s' % musicbrainzngs.compat.quote_plus(expected_query)
+        self.assertEquals(expected, self.opener.get_url())
+
+        # Invalid query field
+        with self.assertRaises(musicbrainzngs.InvalidSearchFieldError):
+            musicbrainzngs.search_places(foo="value")
+
+    def test_search_releases(self):
+        musicbrainzngs.search_releases("Affordable Pop Music")
+        self.assertEqual("http://musicbrainz.org/ws/2/release/?query=Affordable+Pop+Music", self.opener.get_url())
+
+        musicbrainzngs.search_releases(release="Affordable Pop Music")
+        expected_query = 'release:(affordable pop music)'
+        expected = 'http://musicbrainz.org/ws/2/release/?query=%s' % musicbrainzngs.compat.quote_plus(expected_query)
+        self.assertEquals(expected, self.opener.get_url())
+
+        # Invalid query field
+        with self.assertRaises(musicbrainzngs.InvalidSearchFieldError):
+            musicbrainzngs.search_releases(foo="value")
+
+    def test_search_release_groups(self):
+        musicbrainzngs.search_release_groups("Affordable Pop Music")
+        self.assertEqual("http://musicbrainz.org/ws/2/release-group/?query=Affordable+Pop+Music", self.opener.get_url())
+
+        musicbrainzngs.search_release_groups(releasegroup="Affordable Pop Music")
+        expected_query = 'releasegroup:(affordable pop music)'
+        expected = 'http://musicbrainz.org/ws/2/release-group/?query=%s' % musicbrainzngs.compat.quote_plus(expected_query)
+        self.assertEquals(expected, self.opener.get_url())
+
+        # Invalid query field
+        with self.assertRaises(musicbrainzngs.InvalidSearchFieldError):
+            musicbrainzngs.search_release_groups(foo="value")
+
+    def test_search_recordings(self):
+        musicbrainzngs.search_recordings("Thief of Hearts")
+        self.assertEqual("http://musicbrainz.org/ws/2/recording/?query=Thief+of+Hearts", self.opener.get_url())
+
+        musicbrainzngs.search_recordings(recording="Thief of Hearts")
+        expected_query = 'recording:(thief of hearts)'
+        expected = 'http://musicbrainz.org/ws/2/recording/?query=%s' % musicbrainzngs.compat.quote_plus(expected_query)
+        self.assertEquals(expected, self.opener.get_url())
+
+        # Invalid query field
+        with self.assertRaises(musicbrainzngs.InvalidSearchFieldError):
+            musicbrainzngs.search_recordings(foo="value")
+
+    def test_search_works(self):
+        musicbrainzngs.search_works("Fountain City")
+        self.assertEqual("http://musicbrainz.org/ws/2/work/?query=Fountain+City", self.opener.get_url())
+
+        musicbrainzngs.search_works(work="Fountain City")
+        expected_query = 'work:(fountain city)'
+        expected = 'http://musicbrainz.org/ws/2/work/?query=%s' % musicbrainzngs.compat.quote_plus(expected_query)
+        self.assertEquals(expected, self.opener.get_url())
+
+        # Invalid query field
+        with self.assertRaises(musicbrainzngs.InvalidSearchFieldError):
+            musicbrainzngs.search_works(foo="value")


### PR DESCRIPTION
We were missing search parameters for event, instrument, and place which
means that any query for these items with a named field would fail.
Also missing a few (new?) fields for some existing types.
Added tests for all searches to ensure that named fields work
as expected, and errors for invalid fields work.
