### PR TITLE
Add missing MusicBrainz items (incl. genre support)

### DIFF
--- a/musicbrainzngs/musicbrainz.py
+++ b/musicbrainzngs/musicbrainz.py
@@ -685,7 +685,7 @@ def _get_auth_type(entity, id, includes):
     """ Some calls require authentication. This returns
     True if a call does, False otherwise
     """
-    if "user-tags" in includes or "user-ratings" in includes:
+    if "user-tags" in includes or "user-ratings" in includes or "user-genres" in includes:
         return AUTH_YES
     elif entity.startswith("collection"):
         if not id:

--- a/musicbrainzngs/musicbrainz.py
+++ b/musicbrainzngs/musicbrainz.py
@@ -33,7 +33,7 @@ TAG_INCLUDES = ["tags", "user-tags"]
 RATING_INCLUDES = ["ratings", "user-ratings"]
 
 VALID_INCLUDES = {
-    'area' : ["aliases", "annotation"] + RELATION_INCLUDES,
+    'area' : ["aliases", "annotation"] + RELATION_INCLUDES + TAG_INCLUDES,
     'artist': [
         "recordings", "releases", "release-groups", "works", # Subqueries
         "various-artists", "discids", "media", "isrcs",
@@ -67,7 +67,7 @@ VALID_INCLUDES = {
     ] + TAG_INCLUDES + RATING_INCLUDES + RELATION_INCLUDES,
     'series': [
         "annotation", "aliases"
-    ] + RELATION_INCLUDES,
+    ] + RELATION_INCLUDES + TAG_INCLUDES,
     'work': [
         "aliases", "annotation"
     ] + TAG_INCLUDES + RATING_INCLUDES + RELATION_INCLUDES,

--- a/musicbrainzngs/musicbrainz.py
+++ b/musicbrainzngs/musicbrainz.py
@@ -29,7 +29,7 @@ LUCENE_SPECIAL = r'([+\-&|!(){}\[\]\^"~*?:\\\/])'
 
 RELATABLE_TYPES = ['area', 'artist', 'label', 'place', 'event', 'recording', 'release', 'release-group', 'series', 'url', 'work', 'instrument']
 RELATION_INCLUDES = [entity + '-rels' for entity in RELATABLE_TYPES]
-TAG_INCLUDES = ["tags", "user-tags"]
+TAG_INCLUDES = ["tags", "user-tags", "genres", "user-genres"]
 RATING_INCLUDES = ["ratings", "user-ratings"]
 
 VALID_INCLUDES = {

--- a/musicbrainzngs/musicbrainz.py
+++ b/musicbrainzngs/musicbrainz.py
@@ -99,7 +99,7 @@ VALID_RELEASE_TYPES = [
     "nat",
     "album", "single", "ep", "broadcast", "other", # primary types
     "compilation", "soundtrack", "spokenword", "interview", "audiobook",
-    "live", "remix", "dj-mix", "mixtape/street", # secondary types
+    "live", "remix", "dj-mix", "mixtape/street", "audio drama" # secondary types
 ]
 #: These can be used to filter whenever releases or release-groups are involved
 VALID_RELEASE_STATUSES = ["official", "promotion", "bootleg", "pseudo-release"]


### PR DESCRIPTION
* Add missing Release Group (secondary) type
* Add missing valid `inc` parameters for Series and Area entities
* Add missing genre `inc` parameters

The big thing here is that this introduces [MusicBrainz genre](https://blog.metabrainz.org/2018/11/02/musicbrainz-introducing-genres/) support into `musicbrainzngs`, which is why I left that as the last of the commits so it's (more) easily rebaseable in case a different approach is desired. :)