### PR TITLE
Default to use MusicBrainz and CAA over HTTPS

### DIFF
--- a/musicbrainzngs/caa.py
+++ b/musicbrainzngs/caa.py
@@ -16,13 +16,16 @@ from musicbrainzngs import musicbrainz
 from musicbrainzngs.util import _unicode
 
 hostname = "coverartarchive.org"
+https = True
 
 
-def set_caa_hostname(new_hostname):
+def set_caa_hostname(new_hostname, use_https=False):
     """Set the base hostname for Cover Art Archive requests.
     Defaults to 'coverartarchive.org'."""
     global hostname
+    global https
     hostname = new_hostname
+    https = use_https
 
 
 def _caa_request(mbid, imageid=None, size=None, entitytype="release"):
@@ -46,7 +49,7 @@ def _caa_request(mbid, imageid=None, size=None, entitytype="release"):
     elif imageid:
         path.append(imageid)
     url = compat.urlunparse((
-        'http',
+        'https' if https else 'http',
         hostname,
         '/%s' % '/'.join(path),
         '',

--- a/musicbrainzngs/caa.py
+++ b/musicbrainzngs/caa.py
@@ -21,7 +21,12 @@ https = True
 
 def set_caa_hostname(new_hostname, use_https=False):
     """Set the base hostname for Cover Art Archive requests.
-    Defaults to 'coverartarchive.org'."""
+    Defaults to 'coverartarchive.org', accessing over https.
+    For backwards compatibility, `use_https` is False by default.
+
+    :param str new_hostname: The hostname (and port) of the CAA server to connect to
+    :param bool use_https: `True` if the host should be accessed using https. Default is `False`
+"""
     global hostname
     global https
     hostname = new_hostname

--- a/musicbrainzngs/musicbrainz.py
+++ b/musicbrainzngs/musicbrainz.py
@@ -300,6 +300,7 @@ def _docstring_impl(name, values):
 
 user = password = ""
 hostname = "musicbrainz.org"
+https = True
 _client = ""
 _useragent = ""
 
@@ -324,12 +325,14 @@ def set_useragent(app, version, contact=None):
     _client = "%s-%s" % (app, version)
     _log.debug("set user-agent to %s" % _useragent)
 
-def set_hostname(new_hostname):
+def set_hostname(new_hostname, use_https=False):
     """Set the hostname for MusicBrainz webservice requests.
     Defaults to 'musicbrainz.org'.
     You can also include a port: 'localhost:8000'."""
     global hostname
+    global https
     hostname = new_hostname
+    https = use_https
 
 # Rate limiting.
 
@@ -633,7 +636,7 @@ def _mb_request(path, method='GET', auth_required=AUTH_NO,
     # Construct the full URL for the request, including hostname and
     # query string.
     url = compat.urlunparse((
-        'http',
+        'https' if https else 'http',
         hostname,
         '/ws/2/%s' % path,
         '',

--- a/musicbrainzngs/musicbrainz.py
+++ b/musicbrainzngs/musicbrainz.py
@@ -325,10 +325,17 @@ def set_useragent(app, version, contact=None):
     _client = "%s-%s" % (app, version)
     _log.debug("set user-agent to %s" % _useragent)
 
+
 def set_hostname(new_hostname, use_https=False):
     """Set the hostname for MusicBrainz webservice requests.
-    Defaults to 'musicbrainz.org'.
-    You can also include a port: 'localhost:8000'."""
+    Defaults to 'musicbrainz.org', accessing over https.
+    For backwards compatibility, `use_https` is False by default.
+
+    :param str new_hostname: The hostname (and port) of the MusicBrainz server to connect to
+    :param bool use_https: `True` if the host should be accessed using https. Default is `False`
+
+    Specify a non-standard port by adding it to the hostname,
+    for example 'localhost:8000'."""
     global hostname
     global https
     hostname = new_hostname

--- a/test/test_browse.py
+++ b/test/test_browse.py
@@ -16,17 +16,17 @@ class BrowseTest(unittest.TestCase):
     def test_browse(self):
         area = "74e50e58-5deb-4b99-93a2-decbb365c07f"
         musicbrainzngs.browse_events(area=area)
-        self.assertEqual("http://musicbrainz.org/ws/2/event/?area=74e50e58-5deb-4b99-93a2-decbb365c07f", self.opener.get_url())
+        self.assertEqual("https://musicbrainz.org/ws/2/event/?area=74e50e58-5deb-4b99-93a2-decbb365c07f", self.opener.get_url())
 
     def test_browse_includes(self):
         area = "74e50e58-5deb-4b99-93a2-decbb365c07f"
         musicbrainzngs.browse_events(area=area, includes=["aliases", "area-rels"])
-        self.assertEqual("http://musicbrainz.org/ws/2/event/?area=74e50e58-5deb-4b99-93a2-decbb365c07f&inc=aliases+area-rels", self.opener.get_url())
+        self.assertEqual("https://musicbrainz.org/ws/2/event/?area=74e50e58-5deb-4b99-93a2-decbb365c07f&inc=aliases+area-rels", self.opener.get_url())
 
     def test_browse_single_include(self):
         area = "74e50e58-5deb-4b99-93a2-decbb365c07f"
         musicbrainzngs.browse_events(area=area, includes="aliases")
-        self.assertEqual("http://musicbrainz.org/ws/2/event/?area=74e50e58-5deb-4b99-93a2-decbb365c07f&inc=aliases", self.opener.get_url())
+        self.assertEqual("https://musicbrainz.org/ws/2/event/?area=74e50e58-5deb-4b99-93a2-decbb365c07f&inc=aliases", self.opener.get_url())
 
     def test_browse_multiple_by(self):
         """It is an error to choose multiple entities to browse by"""
@@ -37,105 +37,105 @@ class BrowseTest(unittest.TestCase):
         """Limit and offset values"""
         area = "74e50e58-5deb-4b99-93a2-decbb365c07f"
         musicbrainzngs.browse_events(area=area, limit=50, offset=100)
-        self.assertEqual("http://musicbrainz.org/ws/2/event/?area=74e50e58-5deb-4b99-93a2-decbb365c07f&limit=50&offset=100", self.opener.get_url())
+        self.assertEqual("https://musicbrainz.org/ws/2/event/?area=74e50e58-5deb-4b99-93a2-decbb365c07f&limit=50&offset=100", self.opener.get_url())
 
     def test_browse_artist(self):
         release = "9ace7c8c-55b4-4c5d-9aa8-e573a5dde9ad"
         musicbrainzngs.browse_artists(release=release)
-        self.assertEqual("http://musicbrainz.org/ws/2/artist/?release=9ace7c8c-55b4-4c5d-9aa8-e573a5dde9ad", self.opener.get_url())
+        self.assertEqual("https://musicbrainz.org/ws/2/artist/?release=9ace7c8c-55b4-4c5d-9aa8-e573a5dde9ad", self.opener.get_url())
 
         recording = "6da2cc31-9b12-4b66-9e26-074150f73406"
         musicbrainzngs.browse_artists(recording=recording)
-        self.assertEqual("http://musicbrainz.org/ws/2/artist/?recording=6da2cc31-9b12-4b66-9e26-074150f73406", self.opener.get_url())
+        self.assertEqual("https://musicbrainz.org/ws/2/artist/?recording=6da2cc31-9b12-4b66-9e26-074150f73406", self.opener.get_url())
 
         release_group = "44c90c72-76b5-3c13-890e-3d37f21c10c9"
         musicbrainzngs.browse_artists(release_group=release_group)
-        self.assertEqual("http://musicbrainz.org/ws/2/artist/?release-group=44c90c72-76b5-3c13-890e-3d37f21c10c9", self.opener.get_url())
+        self.assertEqual("https://musicbrainz.org/ws/2/artist/?release-group=44c90c72-76b5-3c13-890e-3d37f21c10c9", self.opener.get_url())
 
         work = "deb27b88-cf41-4f7c-b3aa-bc3268bc3c02"
         musicbrainzngs.browse_artists(work=work)
-        self.assertEqual("http://musicbrainz.org/ws/2/artist/?work=deb27b88-cf41-4f7c-b3aa-bc3268bc3c02", self.opener.get_url())
+        self.assertEqual("https://musicbrainz.org/ws/2/artist/?work=deb27b88-cf41-4f7c-b3aa-bc3268bc3c02", self.opener.get_url())
 
     def test_browse_event(self):
         area = "f03d09b3-39dc-4083-afd6-159e3f0d462f"
         musicbrainzngs.browse_events(area=area)
-        self.assertEqual("http://musicbrainz.org/ws/2/event/?area=f03d09b3-39dc-4083-afd6-159e3f0d462f", self.opener.get_url())
+        self.assertEqual("https://musicbrainz.org/ws/2/event/?area=f03d09b3-39dc-4083-afd6-159e3f0d462f", self.opener.get_url())
 
         artist = "0383dadf-2a4e-4d10-a46a-e9e041da8eb3"
         musicbrainzngs.browse_events(artist=artist)
-        self.assertEqual("http://musicbrainz.org/ws/2/event/?artist=0383dadf-2a4e-4d10-a46a-e9e041da8eb3", self.opener.get_url())
+        self.assertEqual("https://musicbrainz.org/ws/2/event/?artist=0383dadf-2a4e-4d10-a46a-e9e041da8eb3", self.opener.get_url())
 
         place = "8a6161bb-fb50-4234-82c5-1e24ab342499"
         musicbrainzngs.browse_events(place=place)
-        self.assertEqual("http://musicbrainz.org/ws/2/event/?place=8a6161bb-fb50-4234-82c5-1e24ab342499", self.opener.get_url())
+        self.assertEqual("https://musicbrainz.org/ws/2/event/?place=8a6161bb-fb50-4234-82c5-1e24ab342499", self.opener.get_url())
 
     def test_browse_label(self):
         release = "c9550260-b7ae-4670-ac24-731c19e76b59"
         musicbrainzngs.browse_labels(release=release)
-        self.assertEqual("http://musicbrainz.org/ws/2/label/?release=c9550260-b7ae-4670-ac24-731c19e76b59", self.opener.get_url())
+        self.assertEqual("https://musicbrainz.org/ws/2/label/?release=c9550260-b7ae-4670-ac24-731c19e76b59", self.opener.get_url())
 
     def test_browse_recording(self):
         artist = "47f67b22-affe-4fe1-9d25-853d69bc0ee3"
         musicbrainzngs.browse_recordings(artist=artist)
-        self.assertEqual("http://musicbrainz.org/ws/2/recording/?artist=47f67b22-affe-4fe1-9d25-853d69bc0ee3", self.opener.get_url())
+        self.assertEqual("https://musicbrainz.org/ws/2/recording/?artist=47f67b22-affe-4fe1-9d25-853d69bc0ee3", self.opener.get_url())
 
         release = "438042ef-7ccc-4d03-9391-4f66427b2055"
         musicbrainzngs.browse_recordings(release=release)
-        self.assertEqual("http://musicbrainz.org/ws/2/recording/?release=438042ef-7ccc-4d03-9391-4f66427b2055", self.opener.get_url())
+        self.assertEqual("https://musicbrainz.org/ws/2/recording/?release=438042ef-7ccc-4d03-9391-4f66427b2055", self.opener.get_url())
 
     def test_browse_place(self):
         area = "74e50e58-5deb-4b99-93a2-decbb365c07f"
         musicbrainzngs.browse_places(area=area)
-        self.assertEqual("http://musicbrainz.org/ws/2/place/?area=74e50e58-5deb-4b99-93a2-decbb365c07f", self.opener.get_url())
+        self.assertEqual("https://musicbrainz.org/ws/2/place/?area=74e50e58-5deb-4b99-93a2-decbb365c07f", self.opener.get_url())
 
 
     def test_browse_release(self):
         artist = "47f67b22-affe-4fe1-9d25-853d69bc0ee3"
         musicbrainzngs.browse_releases(artist=artist)
-        self.assertEqual("http://musicbrainz.org/ws/2/release/?artist=47f67b22-affe-4fe1-9d25-853d69bc0ee3", self.opener.get_url())
+        self.assertEqual("https://musicbrainz.org/ws/2/release/?artist=47f67b22-affe-4fe1-9d25-853d69bc0ee3", self.opener.get_url())
         musicbrainzngs.browse_releases(track_artist=artist)
-        self.assertEqual("http://musicbrainz.org/ws/2/release/?track_artist=47f67b22-affe-4fe1-9d25-853d69bc0ee3", self.opener.get_url())
+        self.assertEqual("https://musicbrainz.org/ws/2/release/?track_artist=47f67b22-affe-4fe1-9d25-853d69bc0ee3", self.opener.get_url())
 
         label = "713c4a95-6616-442b-9cf6-14e1ddfd5946"
         musicbrainzngs.browse_releases(label=label)
-        self.assertEqual("http://musicbrainz.org/ws/2/release/?label=713c4a95-6616-442b-9cf6-14e1ddfd5946", self.opener.get_url())
+        self.assertEqual("https://musicbrainz.org/ws/2/release/?label=713c4a95-6616-442b-9cf6-14e1ddfd5946", self.opener.get_url())
 
         recording = "7484fcfd-1968-4401-a44d-d1edcc580518"
         musicbrainzngs.browse_releases(recording=recording)
-        self.assertEqual("http://musicbrainz.org/ws/2/release/?recording=7484fcfd-1968-4401-a44d-d1edcc580518", self.opener.get_url())
+        self.assertEqual("https://musicbrainz.org/ws/2/release/?recording=7484fcfd-1968-4401-a44d-d1edcc580518", self.opener.get_url())
 
         release_group = "1c1b54f7-e56a-3ce8-b62c-e45c378e7f76"
         musicbrainzngs.browse_releases(release_group=release_group)
-        self.assertEqual("http://musicbrainz.org/ws/2/release/?release-group=1c1b54f7-e56a-3ce8-b62c-e45c378e7f76", self.opener.get_url())
+        self.assertEqual("https://musicbrainz.org/ws/2/release/?release-group=1c1b54f7-e56a-3ce8-b62c-e45c378e7f76", self.opener.get_url())
 
     def test_browse_release_group(self):
         artist = "47f67b22-affe-4fe1-9d25-853d69bc0ee3"
         musicbrainzngs.browse_release_groups(artist=artist)
-        self.assertEqual("http://musicbrainz.org/ws/2/release-group/?artist=47f67b22-affe-4fe1-9d25-853d69bc0ee3", self.opener.get_url())
+        self.assertEqual("https://musicbrainz.org/ws/2/release-group/?artist=47f67b22-affe-4fe1-9d25-853d69bc0ee3", self.opener.get_url())
 
         release = "438042ef-7ccc-4d03-9391-4f66427b2055"
         musicbrainzngs.browse_release_groups(release=release)
-        self.assertEqual("http://musicbrainz.org/ws/2/release-group/?release=438042ef-7ccc-4d03-9391-4f66427b2055", self.opener.get_url())
+        self.assertEqual("https://musicbrainz.org/ws/2/release-group/?release=438042ef-7ccc-4d03-9391-4f66427b2055", self.opener.get_url())
 
         release = "438042ef-7ccc-4d03-9391-4f66427b2055"
         rel_type = "ep"
         musicbrainzngs.browse_release_groups(release=release, release_type=rel_type)
-        self.assertEqual("http://musicbrainz.org/ws/2/release-group/?release=438042ef-7ccc-4d03-9391-4f66427b2055&type=ep", self.opener.get_url())
+        self.assertEqual("https://musicbrainz.org/ws/2/release-group/?release=438042ef-7ccc-4d03-9391-4f66427b2055&type=ep", self.opener.get_url())
 
     def test_browse_url(self):
         resource = "http://www.queenonline.com"
         musicbrainzngs.browse_urls(resource=resource)
-        self.assertEqual("http://musicbrainz.org/ws/2/url/?resource=http%3A%2F%2Fwww.queenonline.com", self.opener.get_url())
+        self.assertEqual("https://musicbrainz.org/ws/2/url/?resource=http%3A%2F%2Fwww.queenonline.com", self.opener.get_url())
 
         # Resource is urlencoded, including ? and =
         resource = "http://www.splendidezine.com/review.html?reviewid=1109588405202831"
         musicbrainzngs.browse_urls(resource=resource)
-        self.assertEqual("http://musicbrainz.org/ws/2/url/?resource=http%3A%2F%2Fwww.splendidezine.com%2Freview.html%3Freviewid%3D1109588405202831", self.opener.get_url())
+        self.assertEqual("https://musicbrainz.org/ws/2/url/?resource=http%3A%2F%2Fwww.splendidezine.com%2Freview.html%3Freviewid%3D1109588405202831", self.opener.get_url())
 
     def test_browse_work(self):
         artist = "0383dadf-2a4e-4d10-a46a-e9e041da8eb3"
         musicbrainzngs.browse_works(artist=artist)
-        self.assertEqual("http://musicbrainz.org/ws/2/work/?artist=0383dadf-2a4e-4d10-a46a-e9e041da8eb3", self.opener.get_url())
+        self.assertEqual("https://musicbrainz.org/ws/2/work/?artist=0383dadf-2a4e-4d10-a46a-e9e041da8eb3", self.opener.get_url())
 
     def test_browse_includes_is_subset_of_includes(self):
         """Check that VALID_BROWSE_INCLUDES is a strict subset of

--- a/test/test_caa.py
+++ b/test/test_caa.py
@@ -15,7 +15,7 @@ class CaaTest(unittest.TestCase):
         self.opener = _common.FakeOpener(resp)
         musicbrainzngs.compat.build_opener = lambda *args: self.opener
         res = caa.get_image_list("8ec178f4-a8e8-4f22-bcba-1964466ef214")
-        self.assertEqual("http://coverartarchive.org/release/8ec178f4-a8e8-4f22-bcba-1964466ef214", self.opener.myurl)
+        self.assertEqual("https://coverartarchive.org/release/8ec178f4-a8e8-4f22-bcba-1964466ef214", self.opener.myurl)
         self.assertEqual(1, len(res))
         self.assertTrue("images" in res)
 
@@ -25,7 +25,7 @@ class CaaTest(unittest.TestCase):
         self.opener = _common.FakeOpener(resp)
         musicbrainzngs.compat.build_opener = lambda *args: self.opener
         res = caa.get_release_group_image_list("8ec178f4-a8e8-4f22-bcba-1964466ef214")
-        self.assertEqual("http://coverartarchive.org/release-group/8ec178f4-a8e8-4f22-bcba-1964466ef214", self.opener.myurl)
+        self.assertEqual("https://coverartarchive.org/release-group/8ec178f4-a8e8-4f22-bcba-1964466ef214", self.opener.myurl)
         self.assertEqual(2, len(res))
         self.assertTrue("images" in res)
         self.assertEqual("foo", res["release"])
@@ -71,7 +71,7 @@ class CaaTest(unittest.TestCase):
         musicbrainzngs.compat.build_opener = lambda *args: self.opener
         res = caa.get_image("8ec178f4-a8e8-4f22-bcba-1964466ef214", "1234")
 
-        self.assertEqual("http://coverartarchive.org/release/8ec178f4-a8e8-4f22-bcba-1964466ef214/1234", self.opener.myurl)
+        self.assertEqual("https://coverartarchive.org/release/8ec178f4-a8e8-4f22-bcba-1964466ef214/1234", self.opener.myurl)
         self.assertEqual(resp, res)
 
     def test_get_size(self):
@@ -80,7 +80,7 @@ class CaaTest(unittest.TestCase):
         musicbrainzngs.compat.build_opener = lambda *args: self.opener
         res = caa.get_image("8ec178f4-a8e8-4f22-bcba-1964466ef214", "1234", 250)
 
-        self.assertEqual("http://coverartarchive.org/release/8ec178f4-a8e8-4f22-bcba-1964466ef214/1234-250", self.opener.myurl)
+        self.assertEqual("https://coverartarchive.org/release/8ec178f4-a8e8-4f22-bcba-1964466ef214/1234-250", self.opener.myurl)
         self.assertEqual(resp, res)
 
     def test_front(self):
@@ -89,7 +89,7 @@ class CaaTest(unittest.TestCase):
         musicbrainzngs.compat.build_opener = lambda *args: self.opener
         res = caa.get_image_front("8ec178f4-a8e8-4f22-bcba-1964466ef214")
 
-        self.assertEqual("http://coverartarchive.org/release/8ec178f4-a8e8-4f22-bcba-1964466ef214/front", self.opener.myurl)
+        self.assertEqual("https://coverartarchive.org/release/8ec178f4-a8e8-4f22-bcba-1964466ef214/front", self.opener.myurl)
         self.assertEqual(resp, res)
 
     def test_release_group_front(self):
@@ -98,7 +98,7 @@ class CaaTest(unittest.TestCase):
         musicbrainzngs.compat.build_opener = lambda *args: self.opener
         res = caa.get_release_group_image_front("8ec178f4-a8e8-4f22-bcba-1964466ef214")
 
-        self.assertEqual("http://coverartarchive.org/release-group/8ec178f4-a8e8-4f22-bcba-1964466ef214/front", self.opener.myurl)
+        self.assertEqual("https://coverartarchive.org/release-group/8ec178f4-a8e8-4f22-bcba-1964466ef214/front", self.opener.myurl)
         self.assertEqual(resp, res)
 
     def test_back(self):
@@ -107,6 +107,6 @@ class CaaTest(unittest.TestCase):
         musicbrainzngs.compat.build_opener = lambda *args: self.opener
         res = caa.get_image_back("8ec178f4-a8e8-4f22-bcba-1964466ef214")
 
-        self.assertEqual("http://coverartarchive.org/release/8ec178f4-a8e8-4f22-bcba-1964466ef214/back", self.opener.myurl)
+        self.assertEqual("https://coverartarchive.org/release/8ec178f4-a8e8-4f22-bcba-1964466ef214/back", self.opener.myurl)
         self.assertEqual(resp, res)
 

--- a/test/test_getentity.py
+++ b/test/test_getentity.py
@@ -16,15 +16,15 @@ class UrlTest(unittest.TestCase):
     def testGetArtist(self):
         artistid = "952a4205-023d-4235-897c-6fdb6f58dfaa"
         musicbrainzngs.get_artist_by_id(artistid)
-        self.assertEqual("http://musicbrainz.org/ws/2/artist/952a4205-023d-4235-897c-6fdb6f58dfaa", self.opener.get_url())
+        self.assertEqual("https://musicbrainz.org/ws/2/artist/952a4205-023d-4235-897c-6fdb6f58dfaa", self.opener.get_url())
 
         # Test an include
         musicbrainzngs.get_artist_by_id(artistid, "recordings")
-        self.assertEqual("http://musicbrainz.org/ws/2/artist/952a4205-023d-4235-897c-6fdb6f58dfaa?inc=recordings", self.opener.get_url())
+        self.assertEqual("https://musicbrainz.org/ws/2/artist/952a4205-023d-4235-897c-6fdb6f58dfaa?inc=recordings", self.opener.get_url())
 
         # More than one include
         musicbrainzngs.get_artist_by_id(artistid, ["recordings", "aliases"])
-        expected ="http://musicbrainz.org/ws/2/artist/952a4205-023d-4235-897c-6fdb6f58dfaa?inc=recordings+aliases"
+        expected ="https://musicbrainz.org/ws/2/artist/952a4205-023d-4235-897c-6fdb6f58dfaa?inc=recordings+aliases"
         self.assertEqual(expected, self.opener.get_url())
 
         # with valid filters
@@ -40,31 +40,31 @@ class UrlTest(unittest.TestCase):
     def testGetEvent(self):
         event_id = "a4a0927c-8ad7-48dd-883c-7126cc0b9c6b"
         musicbrainzngs.get_event_by_id(event_id)
-        self.assertEqual("http://musicbrainz.org/ws/2/event/a4a0927c-8ad7-48dd-883c-7126cc0b9c6b", self.opener.get_url())
+        self.assertEqual("https://musicbrainz.org/ws/2/event/a4a0927c-8ad7-48dd-883c-7126cc0b9c6b", self.opener.get_url())
 
         # one include
         musicbrainzngs.get_event_by_id(event_id, ["artist-rels"])
-        self.assertEqual("http://musicbrainz.org/ws/2/event/a4a0927c-8ad7-48dd-883c-7126cc0b9c6b?inc=artist-rels", self.opener.get_url())
+        self.assertEqual("https://musicbrainz.org/ws/2/event/a4a0927c-8ad7-48dd-883c-7126cc0b9c6b?inc=artist-rels", self.opener.get_url())
 
         musicbrainzngs.get_event_by_id(event_id, ["artist-rels", "event-rels", "ratings", "tags"])
-        self.assertEqual("http://musicbrainz.org/ws/2/event/a4a0927c-8ad7-48dd-883c-7126cc0b9c6b?inc=artist-rels+event-rels+ratings+tags", self.opener.get_url())
+        self.assertEqual("https://musicbrainz.org/ws/2/event/a4a0927c-8ad7-48dd-883c-7126cc0b9c6b?inc=artist-rels+event-rels+ratings+tags", self.opener.get_url())
 
     def testGetPlace(self):
         place_id = "43e166a5-a024-4cbb-9a1f-d4947b4ff489"
         musicbrainzngs.get_place_by_id(place_id)
-        self.assertEqual("http://musicbrainz.org/ws/2/place/43e166a5-a024-4cbb-9a1f-d4947b4ff489", self.opener.get_url())
+        self.assertEqual("https://musicbrainz.org/ws/2/place/43e166a5-a024-4cbb-9a1f-d4947b4ff489", self.opener.get_url())
 
         musicbrainzngs.get_place_by_id(place_id, ["event-rels"])
-        self.assertEqual("http://musicbrainz.org/ws/2/place/43e166a5-a024-4cbb-9a1f-d4947b4ff489?inc=event-rels", self.opener.get_url())
+        self.assertEqual("https://musicbrainz.org/ws/2/place/43e166a5-a024-4cbb-9a1f-d4947b4ff489?inc=event-rels", self.opener.get_url())
 
     def testGetLabel(self):
         label_id = "aab2e720-bdd2-4565-afc2-460743585f16"
         musicbrainzngs.get_label_by_id(label_id)
-        self.assertEqual("http://musicbrainz.org/ws/2/label/aab2e720-bdd2-4565-afc2-460743585f16", self.opener.get_url())
+        self.assertEqual("https://musicbrainz.org/ws/2/label/aab2e720-bdd2-4565-afc2-460743585f16", self.opener.get_url())
 
         # one include
         musicbrainzngs.get_label_by_id(label_id, "releases")
-        self.assertEqual("http://musicbrainz.org/ws/2/label/aab2e720-bdd2-4565-afc2-460743585f16?inc=releases", self.opener.get_url())
+        self.assertEqual("https://musicbrainz.org/ws/2/label/aab2e720-bdd2-4565-afc2-460743585f16?inc=releases", self.opener.get_url())
 
         # with valid filters
         musicbrainzngs.get_label_by_id(label_id, ["releases"],
@@ -74,22 +74,22 @@ class UrlTest(unittest.TestCase):
 
     def testGetRecording(self):
         musicbrainzngs.get_recording_by_id("93468a09-9662-4886-a227-56a2ad1c5246")
-        self.assertEqual("http://musicbrainz.org/ws/2/recording/93468a09-9662-4886-a227-56a2ad1c5246", self.opener.get_url())
+        self.assertEqual("https://musicbrainz.org/ws/2/recording/93468a09-9662-4886-a227-56a2ad1c5246", self.opener.get_url())
 
         # one include
         musicbrainzngs.get_recording_by_id("93468a09-9662-4886-a227-56a2ad1c5246", includes=["artists"])
-        self.assertEqual("http://musicbrainz.org/ws/2/recording/93468a09-9662-4886-a227-56a2ad1c5246?inc=artists", self.opener.get_url())
+        self.assertEqual("https://musicbrainz.org/ws/2/recording/93468a09-9662-4886-a227-56a2ad1c5246?inc=artists", self.opener.get_url())
 
 
     def testGetReleasegroup(self):
         musicbrainzngs.get_release_group_by_id("9377d65d-ffd5-35d6-b64d-43f86ef9188d")
-        self.assertEqual("http://musicbrainz.org/ws/2/release-group/9377d65d-ffd5-35d6-b64d-43f86ef9188d", self.opener.get_url())
+        self.assertEqual("https://musicbrainz.org/ws/2/release-group/9377d65d-ffd5-35d6-b64d-43f86ef9188d", self.opener.get_url())
 
         # one include
         release_group_id = "9377d65d-ffd5-35d6-b64d-43f86ef9188d"
         musicbrainzngs.get_release_group_by_id(release_group_id,
                 includes=["artists"])
-        self.assertEqual("http://musicbrainz.org/ws/2/release-group/9377d65d-ffd5-35d6-b64d-43f86ef9188d?inc=artists", self.opener.get_url())
+        self.assertEqual("https://musicbrainz.org/ws/2/release-group/9377d65d-ffd5-35d6-b64d-43f86ef9188d?inc=artists", self.opener.get_url())
 
         # with valid filters
         musicbrainzngs.get_release_group_by_id(release_group_id,
@@ -104,39 +104,39 @@ class UrlTest(unittest.TestCase):
 
     def testGetWork(self):
         musicbrainzngs.get_work_by_id("c6dfad5a-f915-41c7-a1c0-e2b606948e69")
-        self.assertEqual("http://musicbrainz.org/ws/2/work/c6dfad5a-f915-41c7-a1c0-e2b606948e69", self.opener.get_url())
+        self.assertEqual("https://musicbrainz.org/ws/2/work/c6dfad5a-f915-41c7-a1c0-e2b606948e69", self.opener.get_url())
 
     def testGetByDiscid(self):
         musicbrainzngs.get_releases_by_discid("I5l9cCSFccLKFEKS.7wqSZAorPU-")
-        self.assertEqual("http://musicbrainz.org/ws/2/discid/I5l9cCSFccLKFEKS.7wqSZAorPU-", self.opener.get_url())
+        self.assertEqual("https://musicbrainz.org/ws/2/discid/I5l9cCSFccLKFEKS.7wqSZAorPU-", self.opener.get_url())
 
         includes = ["artists"]
         musicbrainzngs.get_releases_by_discid("I5l9cCSFccLKFEKS.7wqSZAorPU-", includes)
-        self.assertEqual("http://musicbrainz.org/ws/2/discid/I5l9cCSFccLKFEKS.7wqSZAorPU-?inc=artists", self.opener.get_url())
+        self.assertEqual("https://musicbrainz.org/ws/2/discid/I5l9cCSFccLKFEKS.7wqSZAorPU-?inc=artists", self.opener.get_url())
 
         musicbrainzngs.get_releases_by_discid("discid", toc="toc")
-        self.assertEqual("http://musicbrainz.org/ws/2/discid/discid?toc=toc", self.opener.get_url())
+        self.assertEqual("https://musicbrainz.org/ws/2/discid/discid?toc=toc", self.opener.get_url())
 
         musicbrainzngs.get_releases_by_discid("discid", toc="toc", cdstubs=False)
-        self.assertEqual("http://musicbrainz.org/ws/2/discid/discid?cdstubs=no&toc=toc", self.opener.get_url())
+        self.assertEqual("https://musicbrainz.org/ws/2/discid/discid?cdstubs=no&toc=toc", self.opener.get_url())
 
 
     def testGetInstrument(self):
 
         musicbrainzngs.get_instrument_by_id("6505f98c-f698-4406-8bf4-8ca43d05c36f")
-        self.assertEqual("http://musicbrainz.org/ws/2/instrument/6505f98c-f698-4406-8bf4-8ca43d05c36f", self.opener.get_url())
+        self.assertEqual("https://musicbrainz.org/ws/2/instrument/6505f98c-f698-4406-8bf4-8ca43d05c36f", self.opener.get_url())
 
         # Tags
         musicbrainzngs.get_instrument_by_id("6505f98c-f698-4406-8bf4-8ca43d05c36f", includes="tags")
-        self.assertEqual("http://musicbrainz.org/ws/2/instrument/6505f98c-f698-4406-8bf4-8ca43d05c36f?inc=tags", self.opener.get_url())
+        self.assertEqual("https://musicbrainz.org/ws/2/instrument/6505f98c-f698-4406-8bf4-8ca43d05c36f?inc=tags", self.opener.get_url())
 
         # some rels
         musicbrainzngs.get_instrument_by_id("6505f98c-f698-4406-8bf4-8ca43d05c36f", includes=["instrument-rels", "url-rels"])
-        self.assertEqual("http://musicbrainz.org/ws/2/instrument/6505f98c-f698-4406-8bf4-8ca43d05c36f?inc=instrument-rels+url-rels", self.opener.get_url())
+        self.assertEqual("https://musicbrainz.org/ws/2/instrument/6505f98c-f698-4406-8bf4-8ca43d05c36f?inc=instrument-rels+url-rels", self.opener.get_url())
 
         # alias, annotation
         musicbrainzngs.get_instrument_by_id("d00cec5f-f9bc-4235-a54f-6639a02d4e4c", includes=["aliases", "annotation"])
-        self.assertEqual("http://musicbrainz.org/ws/2/instrument/d00cec5f-f9bc-4235-a54f-6639a02d4e4c?inc=aliases+annotation", self.opener.get_url())
+        self.assertEqual("https://musicbrainz.org/ws/2/instrument/d00cec5f-f9bc-4235-a54f-6639a02d4e4c?inc=aliases+annotation", self.opener.get_url())
 
         # Ratings are used on almost all other entites but instrument
         self.assertRaises(musicbrainzngs.UsageError,

--- a/test/test_mbxml_collection.py
+++ b/test/test_mbxml_collection.py
@@ -18,22 +18,22 @@ class UrlTest(unittest.TestCase):
 
     def testGetCollection(self):
         musicbrainzngs.get_releases_in_collection("0b15c97c-8eb8-4b4f-81c3-0eb24266a2ac")
-        self.assertEqual("http://musicbrainz.org/ws/2/collection/0b15c97c-8eb8-4b4f-81c3-0eb24266a2ac/releases", self.opener.get_url())
+        self.assertEqual("https://musicbrainz.org/ws/2/collection/0b15c97c-8eb8-4b4f-81c3-0eb24266a2ac/releases", self.opener.get_url())
 
         musicbrainzngs.get_works_in_collection("898676a6-bc79-4fe2-98ae-79c5940fe1a2")
-        self.assertEqual("http://musicbrainz.org/ws/2/collection/898676a6-bc79-4fe2-98ae-79c5940fe1a2/works", self.opener.get_url())
+        self.assertEqual("https://musicbrainz.org/ws/2/collection/898676a6-bc79-4fe2-98ae-79c5940fe1a2/works", self.opener.get_url())
 
         musicbrainzngs.get_events_in_collection("65cb5dda-44aa-44a8-9c0d-4f99a14ab944")
-        self.assertEqual("http://musicbrainz.org/ws/2/collection/65cb5dda-44aa-44a8-9c0d-4f99a14ab944/events", self.opener.get_url())
+        self.assertEqual("https://musicbrainz.org/ws/2/collection/65cb5dda-44aa-44a8-9c0d-4f99a14ab944/events", self.opener.get_url())
 
         musicbrainzngs.get_places_in_collection("9dde4c3c-520a-4bfd-9aae-446c3a04ce0c")
-        self.assertEqual("http://musicbrainz.org/ws/2/collection/9dde4c3c-520a-4bfd-9aae-446c3a04ce0c/places", self.opener.get_url())
+        self.assertEqual("https://musicbrainz.org/ws/2/collection/9dde4c3c-520a-4bfd-9aae-446c3a04ce0c/places", self.opener.get_url())
 
         musicbrainzngs.get_recordings_in_collection("42bc6dd9-8deb-4bd7-83eb-5dacdb218b38")
-        self.assertEqual("http://musicbrainz.org/ws/2/collection/42bc6dd9-8deb-4bd7-83eb-5dacdb218b38/recordings", self.opener.get_url())
+        self.assertEqual("https://musicbrainz.org/ws/2/collection/42bc6dd9-8deb-4bd7-83eb-5dacdb218b38/recordings", self.opener.get_url())
 
         musicbrainzngs.get_artists_in_collection("7e582256-b3ce-421f-82ba-451b0ab080eb")
-        self.assertEqual("http://musicbrainz.org/ws/2/collection/7e582256-b3ce-421f-82ba-451b0ab080eb/artists", self.opener.get_url())
+        self.assertEqual("https://musicbrainz.org/ws/2/collection/7e582256-b3ce-421f-82ba-451b0ab080eb/artists", self.opener.get_url())
 
 
 class GetCollectionTest(unittest.TestCase):

--- a/test/test_mbxml_discid.py
+++ b/test/test_mbxml_discid.py
@@ -18,16 +18,16 @@ class UrlTest(unittest.TestCase):
 
     def testGetDiscId(self):
         musicbrainzngs.get_releases_by_discid("xp5tz6rE4OHrBafj0bLfDRMGK48-")
-        self.assertEqual("http://musicbrainz.org/ws/2/discid/xp5tz6rE4OHrBafj0bLfDRMGK48-", self.opener.get_url())
+        self.assertEqual("https://musicbrainz.org/ws/2/discid/xp5tz6rE4OHrBafj0bLfDRMGK48-", self.opener.get_url())
 
         # one include
         musicbrainzngs.get_releases_by_discid("xp5tz6rE4OHrBafj0bLfDRMGK48-",
                 includes=["recordings"])
-        self.assertEqual("http://musicbrainz.org/ws/2/discid/xp5tz6rE4OHrBafj0bLfDRMGK48-?inc=recordings", self.opener.get_url())
+        self.assertEqual("https://musicbrainz.org/ws/2/discid/xp5tz6rE4OHrBafj0bLfDRMGK48-?inc=recordings", self.opener.get_url())
 
         # more than one include
         musicbrainzngs.get_releases_by_discid("xp5tz6rE4OHrBafj0bLfDRMGK48-", includes=["artists", "recordings", "artist-credits"])
-        expected = "http://musicbrainz.org/ws/2/discid/xp5tz6rE4OHrBafj0bLfDRMGK48-?inc=artists+recordings+artist-credits"
+        expected = "https://musicbrainz.org/ws/2/discid/xp5tz6rE4OHrBafj0bLfDRMGK48-?inc=artists+recordings+artist-credits"
         self.assertEqual(expected, self.opener.get_url())
 
 

--- a/test/test_mbxml_release.py
+++ b/test/test_mbxml_release.py
@@ -18,15 +18,15 @@ class UrlTest(unittest.TestCase):
 
     def testGetRelease(self):
         musicbrainzngs.get_release_by_id("5e3524ca-b4a1-4e51-9ba5-63ea2de8f49b")
-        self.assertEqual("http://musicbrainz.org/ws/2/release/5e3524ca-b4a1-4e51-9ba5-63ea2de8f49b", self.opener.get_url())
+        self.assertEqual("https://musicbrainz.org/ws/2/release/5e3524ca-b4a1-4e51-9ba5-63ea2de8f49b", self.opener.get_url())
 
         # one include
         musicbrainzngs.get_release_by_id("5e3524ca-b4a1-4e51-9ba5-63ea2de8f49b", includes=["artists"])
-        self.assertEqual("http://musicbrainz.org/ws/2/release/5e3524ca-b4a1-4e51-9ba5-63ea2de8f49b?inc=artists", self.opener.get_url())
+        self.assertEqual("https://musicbrainz.org/ws/2/release/5e3524ca-b4a1-4e51-9ba5-63ea2de8f49b?inc=artists", self.opener.get_url())
 
         # more than one include
         musicbrainzngs.get_release_by_id("5e3524ca-b4a1-4e51-9ba5-63ea2de8f49b", includes=["artists", "recordings", "artist-credits"])
-        expected = "http://musicbrainz.org/ws/2/release/5e3524ca-b4a1-4e51-9ba5-63ea2de8f49b?inc=artists+recordings+artist-credits"
+        expected = "https://musicbrainz.org/ws/2/release/5e3524ca-b4a1-4e51-9ba5-63ea2de8f49b?inc=artists+recordings+artist-credits"
         self.assertEqual(expected, self.opener.get_url())
 
 

--- a/test/test_search.py
+++ b/test/test_search.py
@@ -16,14 +16,14 @@ class SearchUrlTest(unittest.TestCase):
 
     def test_search_annotations(self):
         musicbrainzngs.search_annotations("Pieds")
-        self.assertEquals("http://musicbrainz.org/ws/2/annotation/?query=Pieds", self.opener.get_url())
+        self.assertEquals("https://musicbrainz.org/ws/2/annotation/?query=Pieds", self.opener.get_url())
 
         # Query fields
         musicbrainzngs.search_annotations(entity="bdb24cb5-404b-4f60-bba4-7b730325ae47")
         # TODO: We escape special characters and then urlencode all query parameters, which may
         # not be necessary, but MusicBrainz accepts it and appears to return the same value as without
         expected_query = 'entity:(bdb24cb5\-404b\-4f60\-bba4\-7b730325ae47)'
-        expected = 'http://musicbrainz.org/ws/2/annotation/?query=%s' % musicbrainzngs.compat.quote_plus(expected_query)
+        expected = 'https://musicbrainz.org/ws/2/annotation/?query=%s' % musicbrainzngs.compat.quote_plus(expected_query)
         self.assertEquals(expected, self.opener.get_url())
 
         # Invalid query field
@@ -32,11 +32,11 @@ class SearchUrlTest(unittest.TestCase):
 
     def test_search_artists(self):
         musicbrainzngs.search_artists("Dynamo Go")
-        self.assertEqual("http://musicbrainz.org/ws/2/artist/?query=Dynamo+Go", self.opener.get_url())
+        self.assertEqual("https://musicbrainz.org/ws/2/artist/?query=Dynamo+Go", self.opener.get_url())
 
         musicbrainzngs.search_artists(artist="Dynamo Go")
         expected_query = 'artist:(dynamo go)'
-        expected = 'http://musicbrainz.org/ws/2/artist/?query=%s' % musicbrainzngs.compat.quote_plus(expected_query)
+        expected = 'https://musicbrainz.org/ws/2/artist/?query=%s' % musicbrainzngs.compat.quote_plus(expected_query)
         self.assertEquals(expected, self.opener.get_url())
 
         # Invalid query field
@@ -45,11 +45,11 @@ class SearchUrlTest(unittest.TestCase):
 
     def test_search_events(self):
         musicbrainzngs.search_events("woodstock")
-        self.assertEqual("http://musicbrainz.org/ws/2/event/?query=woodstock", self.opener.get_url())
+        self.assertEqual("https://musicbrainz.org/ws/2/event/?query=woodstock", self.opener.get_url())
 
         musicbrainzngs.search_events(event="woodstock")
         expected_query = 'event:(woodstock)'
-        expected = 'http://musicbrainz.org/ws/2/event/?query=%s' % musicbrainzngs.compat.quote_plus(expected_query)
+        expected = 'https://musicbrainz.org/ws/2/event/?query=%s' % musicbrainzngs.compat.quote_plus(expected_query)
         self.assertEquals(expected, self.opener.get_url())
 
         # Invalid query field
@@ -58,11 +58,11 @@ class SearchUrlTest(unittest.TestCase):
 
     def test_search_labels(self):
         musicbrainzngs.search_labels("Waysafe")
-        self.assertEqual("http://musicbrainz.org/ws/2/label/?query=Waysafe", self.opener.get_url())
+        self.assertEqual("https://musicbrainz.org/ws/2/label/?query=Waysafe", self.opener.get_url())
 
         musicbrainzngs.search_labels(label="Waysafe")
         expected_query = 'label:(waysafe)'
-        expected = 'http://musicbrainz.org/ws/2/label/?query=%s' % musicbrainzngs.compat.quote_plus(expected_query)
+        expected = 'https://musicbrainz.org/ws/2/label/?query=%s' % musicbrainzngs.compat.quote_plus(expected_query)
         self.assertEquals(expected, self.opener.get_url())
 
         # Invalid query field
@@ -71,11 +71,11 @@ class SearchUrlTest(unittest.TestCase):
 
     def test_search_places(self):
         musicbrainzngs.search_places("Fillmore")
-        self.assertEqual("http://musicbrainz.org/ws/2/place/?query=Fillmore", self.opener.get_url())
+        self.assertEqual("https://musicbrainz.org/ws/2/place/?query=Fillmore", self.opener.get_url())
 
         musicbrainzngs.search_places(place="Fillmore")
         expected_query = 'place:(fillmore)'
-        expected = 'http://musicbrainz.org/ws/2/place/?query=%s' % musicbrainzngs.compat.quote_plus(expected_query)
+        expected = 'https://musicbrainz.org/ws/2/place/?query=%s' % musicbrainzngs.compat.quote_plus(expected_query)
         self.assertEquals(expected, self.opener.get_url())
 
         # Invalid query field
@@ -84,11 +84,11 @@ class SearchUrlTest(unittest.TestCase):
 
     def test_search_releases(self):
         musicbrainzngs.search_releases("Affordable Pop Music")
-        self.assertEqual("http://musicbrainz.org/ws/2/release/?query=Affordable+Pop+Music", self.opener.get_url())
+        self.assertEqual("https://musicbrainz.org/ws/2/release/?query=Affordable+Pop+Music", self.opener.get_url())
 
         musicbrainzngs.search_releases(release="Affordable Pop Music")
         expected_query = 'release:(affordable pop music)'
-        expected = 'http://musicbrainz.org/ws/2/release/?query=%s' % musicbrainzngs.compat.quote_plus(expected_query)
+        expected = 'https://musicbrainz.org/ws/2/release/?query=%s' % musicbrainzngs.compat.quote_plus(expected_query)
         self.assertEquals(expected, self.opener.get_url())
 
         # Invalid query field
@@ -97,11 +97,11 @@ class SearchUrlTest(unittest.TestCase):
 
     def test_search_release_groups(self):
         musicbrainzngs.search_release_groups("Affordable Pop Music")
-        self.assertEqual("http://musicbrainz.org/ws/2/release-group/?query=Affordable+Pop+Music", self.opener.get_url())
+        self.assertEqual("https://musicbrainz.org/ws/2/release-group/?query=Affordable+Pop+Music", self.opener.get_url())
 
         musicbrainzngs.search_release_groups(releasegroup="Affordable Pop Music")
         expected_query = 'releasegroup:(affordable pop music)'
-        expected = 'http://musicbrainz.org/ws/2/release-group/?query=%s' % musicbrainzngs.compat.quote_plus(expected_query)
+        expected = 'https://musicbrainz.org/ws/2/release-group/?query=%s' % musicbrainzngs.compat.quote_plus(expected_query)
         self.assertEquals(expected, self.opener.get_url())
 
         # Invalid query field
@@ -110,11 +110,11 @@ class SearchUrlTest(unittest.TestCase):
 
     def test_search_recordings(self):
         musicbrainzngs.search_recordings("Thief of Hearts")
-        self.assertEqual("http://musicbrainz.org/ws/2/recording/?query=Thief+of+Hearts", self.opener.get_url())
+        self.assertEqual("https://musicbrainz.org/ws/2/recording/?query=Thief+of+Hearts", self.opener.get_url())
 
         musicbrainzngs.search_recordings(recording="Thief of Hearts")
         expected_query = 'recording:(thief of hearts)'
-        expected = 'http://musicbrainz.org/ws/2/recording/?query=%s' % musicbrainzngs.compat.quote_plus(expected_query)
+        expected = 'https://musicbrainz.org/ws/2/recording/?query=%s' % musicbrainzngs.compat.quote_plus(expected_query)
         self.assertEquals(expected, self.opener.get_url())
 
         # Invalid query field
@@ -123,11 +123,11 @@ class SearchUrlTest(unittest.TestCase):
 
     def test_search_works(self):
         musicbrainzngs.search_works("Fountain City")
-        self.assertEqual("http://musicbrainz.org/ws/2/work/?query=Fountain+City", self.opener.get_url())
+        self.assertEqual("https://musicbrainz.org/ws/2/work/?query=Fountain+City", self.opener.get_url())
 
         musicbrainzngs.search_works(work="Fountain City")
         expected_query = 'work:(fountain city)'
-        expected = 'http://musicbrainz.org/ws/2/work/?query=%s' % musicbrainzngs.compat.quote_plus(expected_query)
+        expected = 'https://musicbrainz.org/ws/2/work/?query=%s' % musicbrainzngs.compat.quote_plus(expected_query)
         self.assertEquals(expected, self.opener.get_url())
 
         # Invalid query field


### PR DESCRIPTION
Adds new "global" `https` boolean variables. This variable will be True by default, but if `set_hostname()` gets called it will default to False. This should allow both using `musicbrainz.org`/`coverartarchive.org` over HTTPS by default, but anyone that have a script setting a custom server (that may not support HTTPS) will continue to work as well.

I didn't see anywhere to denote that Python 2.7.6 would be the minimal supported version for this (as per my comment: https://github.com/alastair/python-musicbrainzngs/issues/197#issuecomment-465531186).

Should resolve https://github.com/alastair/python-musicbrainzngs/issues/197