### PR TITLE
Specify supported version(s) of Python in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setup(
     author="Alastair Porter",
     author_email="alastair@porter.net.nz",
     url="https://python-musicbrainzngs.readthedocs.org/",
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     packages=['musicbrainzngs'],
     cmdclass={'test': test },
     license='BSD 2-clause',


### PR DESCRIPTION
This specifies which versions of Python the library is compatible with. This both prevents the module from being installed in an incompatible Python environment, and will also enable users after future releases to still `pip install musicbrainzngs` and get a version that is compatible with their Python setup.

Versions are based on the ones currently being tested for in Travis according to `.travis.yml`.

See https://packaging.python.org/guides/dropping-older-python-versions/ and https://github.com/pypa/sampleproject/pull/87