### PR TITLE
Add missing MusicBrainz items (incl. genre support) (PR takeover)

### DIFF
--- a/musicbrainzngs/musicbrainz.py
+++ b/musicbrainzngs/musicbrainz.py
@@ -33,7 +33,7 @@ TAG_INCLUDES = ["tags", "user-tags"]
 RATING_INCLUDES = ["ratings", "user-ratings"]
 
 VALID_INCLUDES = {
-    'area' : ["aliases", "annotation"] + RELATION_INCLUDES,
+    'area' : ["aliases", "annotation"] + RELATION_INCLUDES + TAG_INCLUDES,
     'artist': [
         "recordings", "releases", "release-groups", "works", # Subqueries
         "various-artists", "discids", "media", "isrcs",
@@ -67,7 +67,7 @@ VALID_INCLUDES = {
     ] + TAG_INCLUDES + RATING_INCLUDES + RELATION_INCLUDES,
     'series': [
         "annotation", "aliases"
-    ] + RELATION_INCLUDES,
+    ] + RELATION_INCLUDES + TAG_INCLUDES,
     'work': [
         "aliases", "annotation"
     ] + TAG_INCLUDES + RATING_INCLUDES + RELATION_INCLUDES,

--- a/musicbrainzngs/musicbrainz.py
+++ b/musicbrainzngs/musicbrainz.py
@@ -29,7 +29,7 @@ LUCENE_SPECIAL = r'([+\-&|!(){}\[\]\^"~*?:\\\/])'
 
 RELATABLE_TYPES = ['area', 'artist', 'label', 'place', 'event', 'recording', 'release', 'release-group', 'series', 'url', 'work', 'instrument']
 RELATION_INCLUDES = [entity + '-rels' for entity in RELATABLE_TYPES]
-TAG_INCLUDES = ["tags", "user-tags"]
+TAG_INCLUDES = ["tags", "user-tags", "genres", "user-genres"]
 RATING_INCLUDES = ["ratings", "user-ratings"]
 
 VALID_INCLUDES = {

--- a/musicbrainzngs/musicbrainz.py
+++ b/musicbrainzngs/musicbrainz.py
@@ -695,7 +695,7 @@ def _get_auth_type(entity, id, includes):
     """ Some calls require authentication. This returns
     True if a call does, False otherwise
     """
-    if "user-tags" in includes or "user-ratings" in includes:
+    if "user-tags" in includes or "user-ratings" in includes or "user-genres" in includes:
         return AUTH_YES
     elif entity.startswith("collection"):
         if not id:

--- a/musicbrainzngs/musicbrainz.py
+++ b/musicbrainzngs/musicbrainz.py
@@ -699,7 +699,7 @@ def _get_auth_type(entity, id, includes):
     """ Some calls require authentication. This returns
     a constant (Yes, No, IfSet) for the auth status of the call.
     """
-    if any(elem in includes for elem in AUTH_REQUIRED_INCLUDES):
+    if "user-tags" in includes or "user-ratings" in includes or "user-genres" in includes:
         return AUTH_YES
     elif entity.startswith("collection"):
         if not id:

--- a/musicbrainzngs/musicbrainz.py
+++ b/musicbrainzngs/musicbrainz.py
@@ -168,6 +168,9 @@ class AUTH_NO: pass
 class AUTH_IFSET: pass
 
 
+AUTH_REQUIRED_INCLUDES = ["user-tags", "user-ratings", "user-genres"]
+
+
 # Exceptions.
 
 class MusicBrainzError(Exception):
@@ -691,11 +694,12 @@ def _mb_request(path, method='GET', auth_required=AUTH_NO,
 
     return parser_fun(resp)
 
+
 def _get_auth_type(entity, id, includes):
     """ Some calls require authentication. This returns
-    True if a call does, False otherwise
+    a constant (Yes, No, IfSet) for the auth status of the call.
     """
-    if "user-tags" in includes or "user-ratings" in includes or "user-genres" in includes:
+    if any(elem in includes for elem in AUTH_REQUIRED_INCLUDES):
         return AUTH_YES
     elif entity.startswith("collection"):
         if not id:
@@ -704,6 +708,7 @@ def _get_auth_type(entity, id, includes):
             return AUTH_IFSET
     else:
         return AUTH_NO
+
 
 def _do_mb_query(entity, id, includes=[], params={}):
 	"""Make a single GET call to the MusicBrainz XML API. `entity` is a

--- a/musicbrainzngs/musicbrainz.py
+++ b/musicbrainzngs/musicbrainz.py
@@ -99,7 +99,7 @@ VALID_RELEASE_TYPES = [
     "nat",
     "album", "single", "ep", "broadcast", "other", # primary types
     "compilation", "soundtrack", "spokenword", "interview", "audiobook",
-    "live", "remix", "dj-mix", "mixtape/street", # secondary types
+    "live", "remix", "dj-mix", "mixtape/street", "audio drama" # secondary types
 ]
 #: These can be used to filter whenever releases or release-groups are involved
 VALID_RELEASE_STATUSES = ["official", "promotion", "bootleg", "pseudo-release"]

--- a/test/_common.py
+++ b/test/_common.py
@@ -20,12 +20,12 @@ except ImportError:
 class FakeOpener(OpenerDirector):
     """ A URL Opener that saves the URL requested and
     returns a dummy response or raises an exception """
-    def __init__(self, response="<response/>", exception=None, handlers=[]):
+    def __init__(self, response="<response/>", exception=None):
         self.myurl = None
         self.headers = None
         self.response = response
         self.exception = exception
-        self.handlers = handlers
+        self.handlers = []
 
     def open(self, request, body=None):
         self.myurl = request.get_full_url()

--- a/test/_common.py
+++ b/test/_common.py
@@ -20,11 +20,12 @@ except ImportError:
 class FakeOpener(OpenerDirector):
     """ A URL Opener that saves the URL requested and
     returns a dummy response or raises an exception """
-    def __init__(self, response="<response/>", exception=None):
+    def __init__(self, response="<response/>", exception=None, handlers=[]):
         self.myurl = None
         self.headers = None
         self.response = response
         self.exception = exception
+        self.handlers = handlers
 
     def open(self, request, body=None):
         self.myurl = request.get_full_url()
@@ -41,6 +42,10 @@ class FakeOpener(OpenerDirector):
 
     def get_url(self):
         return self.myurl
+
+    def add_handlers_and_return(self, handlers=[]):
+        self.handlers.extend(handlers)
+        return self
 
 
 # Mock timing.

--- a/test/test_collection.py
+++ b/test/test_collection.py
@@ -23,6 +23,15 @@ class CollectionTest(unittest.TestCase):
                 "foo/releases", [])
         self.assertEqual(musicbrainzngs.musicbrainz.AUTH_IFSET, ar)
 
+        ar = musicbrainzngs.musicbrainz._get_auth_type("artist", "5b11f4ce-a62d-471e-81fc-a69a8278c7da", [])
+        self.assertEqual(musicbrainzngs.musicbrainz.AUTH_NO, ar)
+
+        ar = musicbrainzngs.musicbrainz._get_auth_type("artist", "5b11f4ce-a62d-471e-81fc-a69a8278c7da", ["user-tags"])
+        self.assertEqual(musicbrainzngs.musicbrainz.AUTH_YES, ar)
+
+        ar = musicbrainzngs.musicbrainz._get_auth_type("artist", "5b11f4ce-a62d-471e-81fc-a69a8278c7da", ["aliases", "user-genres", "artist-rels"])
+        self.assertEqual(musicbrainzngs.musicbrainz.AUTH_YES, ar)
+
     def test_my_collections(self):
         """ If you ask for your collections, you need to have
         authenticated first."""

--- a/test/test_requests.py
+++ b/test/test_requests.py
@@ -50,6 +50,19 @@ class ArgumentTest(unittest.TestCase):
         req = musicbrainz._mb_request(path="foo", auth_required=musicbrainz.AUTH_YES)
         assert(any([isinstance(handler, musicbrainz._DigestAuthHandler) for handler in self.opener.handlers]))
 
+    def test_auth_headers_ifset(self):
+        musicbrainz._useragent = "test"
+        musicbrainz.auth("user", "password")
+        req = musicbrainz._mb_request(path="foo", auth_required=musicbrainz.AUTH_IFSET)
+        assert(any([isinstance(handler, musicbrainz._DigestAuthHandler) for handler in self.opener.handlers]))
+
+    def test_auth_headers_ifset_no_user(self):
+        musicbrainz._useragent = "test"
+        musicbrainz.auth("", "")
+        # if no user and password, auth is not set for AUTH_IFSET
+        req = musicbrainz._mb_request(path="foo", auth_required=musicbrainz.AUTH_IFSET)
+        assert(not any([isinstance(handler, musicbrainz._DigestAuthHandler) for handler in self.opener.handlers]))
+
 
 class MethodTest(unittest.TestCase):
     """Tests the various _do_mb_* methods to ensure they're setting the

--- a/test/test_requests.py
+++ b/test/test_requests.py
@@ -48,7 +48,7 @@ class ArgumentTest(unittest.TestCase):
         musicbrainz._useragent = "test"
         musicbrainz.auth("user", "password")
         req = musicbrainz._mb_request(path="foo", auth_required=musicbrainz.AUTH_YES)
-        assert(any([type(handler) == musicbrainz._DigestAuthHandler for handler in self.opener.handlers]))
+        assert(any([isinstance(handler, musicbrainz._DigestAuthHandler) for handler in self.opener.handlers]))
 
 
 class MethodTest(unittest.TestCase):

--- a/test/test_requests.py
+++ b/test/test_requests.py
@@ -47,14 +47,8 @@ class ArgumentTest(unittest.TestCase):
     def test_auth_headers(self):
         musicbrainz._useragent = "test"
         musicbrainz.auth("user", "password")
-        safe_read_orig = musicbrainz._safe_read
-        parser_fun_orig = musicbrainz.parser_fun
-        musicbrainz.parser_fun = lambda resp: resp
-        musicbrainz._safe_read = lambda opener, req, body: req
         req = musicbrainz._mb_request(path="foo", auth_required=musicbrainz.AUTH_YES)
         assert(any([type(handler) == musicbrainz._DigestAuthHandler for handler in self.opener.handlers]))
-        musicbrainz._safe_read = safe_read_orig
-        musicbrainz.parser_fun = parser_fun_orig
 
 
 class MethodTest(unittest.TestCase):


### PR DESCRIPTION
This pull request is based upon the work of PR #243 as that one is still open and the issues raised where not taken up.

The following issues raised in #243 should be fixed with this PR:
* add ```AUTH_REQUIRED_INCLUDES``` constant containing all includes needing auth
* add tests for ```we correctly raise an exception if one of these includes is set and the user hasn't authenticated``` (there is already a test that checks for: if ```AUTH_YES``` is set and no user then an exception is thrown. I only added a test that inluding one of ```AUTH_REQUIRED_INCLUDES``` returns ```AUTH_YES```. I think that should be enough but could also add a component test, testing more methods.)

It doesn't (yet) add a test for ```we correctly send the auth header if one of these includes is set and the user has authenticated```