### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -112,7 +112,7 @@ already seen so the web service doesn't give you the same results again.
 Browsing
 --------
 
-You can browse entitities of a certain type linked to one specific entity.
+You can browse entities of a certain type linked to one specific entity.
 That is you can browse all recordings by an artist, for example.
 
 These functions can be used to to include more than the maximum of 25 linked

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -40,7 +40,7 @@ itself. The affected functions state this requirement in their documentation.
 The user and password used for authentication are the same as for the
 MusicBrainz website itself and can be set with the :meth:`musicbrainzngs.auth`
 method. After calling this function, the credentials will be saved and
-automaticall used by all functions requiring them.
+automatically used by all functions requiring them.
 
 If a method requiring authentication is called without authenticating, a
 :exc:`musicbrainzngs.UsageError` will be raised.
@@ -207,7 +207,7 @@ An example using :func:`musicbrainzngs.submit_barcodes` looks like this::
   }
   musicbrainzngs.submit_barcodes(barcodes)
 
-See :ref:`api_submitting` in the API for other possibilites.
+See :ref:`api_submitting` in the API for other possibilities.
 
 More Examples
 -------------

--- a/examples/collection.py
+++ b/examples/collection.py
@@ -163,7 +163,7 @@ if __name__ == '__main__':
     musicbrainzngs.auth(username, password)
 
     if args:
-        # Actions for a specific collction.
+        # Actions for a specific collection.
         collection_id = args[0]
         if options.add:
             if option.type == "release":


### PR DESCRIPTION
There are small typos in:
- docs/api.rst
- docs/usage.rst
- examples/collection.py

Fixes:
- Should read `possibilities` rather than `possibilites`.
- Should read `entities` rather than `entitities`.
- Should read `collection` rather than `collction`.
- Should read `automatically` rather than `automaticall`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md