### PR TITLE
Add browse_collections method

### DIFF
--- a/examples/browse.py
+++ b/examples/browse.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+"""
+Browse entities on musicbrainz
+"""
+import json
+import sys
+from argparse import ArgumentParser
+
+import musicbrainzngs
+
+musicbrainzngs.set_useragent(
+    "python-musicbrainzngs-example",
+    "0.1",
+    "https://github.com/alastair/python-musicbrainzngs/",
+)
+
+if __name__ == '__main__':
+    parser = ArgumentParser()
+    parser.add_argument(
+        "entity_type",
+        choices=["collection"],
+        help="The type of entity we're trying to get"
+    )
+    parser.add_argument("linked_entity_type", help="The entity type it's linked to")
+    parser.add_argument("mbid", help="The ID of the linked entity")
+    args = parser.parse_args()
+
+    result = {}
+    if args.entity_type == "collection":
+        result = musicbrainzngs.browse_collections(args.linked_entity_type, args.mbid)
+    else:
+        print("Invalid entity type passed", file=sys.stderr)
+        exit(1)
+    print(json.dumps(result, indent=2))

--- a/test/test_browse.py
+++ b/test/test_browse.py
@@ -59,6 +59,13 @@ class BrowseTest(unittest.TestCase):
         musicbrainzngs.browse_artists(work=work)
         self.assertEqual("https://musicbrainz.org/ws/2/artist/?work=deb27b88-cf41-4f7c-b3aa-bc3268bc3c02", self.opener.get_url())
 
+    def test_browse_collection(self):
+        musicbrainzngs.browse_collections("release", "5fa83c79-ef7d-42ad-8a09-30a1d4c35f63")
+        self.assertEqual("https://musicbrainz.org/ws/2/collection/?release=5fa83c79-ef7d-42ad-8a09-30a1d4c35f63", self.opener.get_url())
+
+        with self.assertRaises(ValueError):
+            musicbrainzngs.browse_collections("I don't exist", "just whatever")
+
     def test_browse_event(self):
         area = "f03d09b3-39dc-4083-afd6-159e3f0d462f"
         musicbrainzngs.browse_events(area=area)


### PR DESCRIPTION
According to the API page, it's possible to find collections that are linked to a bunch of other entities: https://musicbrainz.org/doc/MusicBrainz_API#Linked_entities

This PR adds the possibility to do that with tests and an example.

Closes #253