### PR TITLE
docs/conf.py: fix doc building with Sphinx >6

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -90,7 +90,7 @@ pygments_style = 'sphinx'
 #modindex_common_prefix = []
 
 extlinks = {
-    'musicbrainz': ('https://musicbrainz.org/doc/%s', ''),
+    'musicbrainz': ('https://musicbrainz.org/doc/%s', '%s'),
 }
 
 intersphinx_mapping = {


### PR DESCRIPTION
See:
- https://github.com/sphinx-doc/sphinx/pull/10471/commits/97e3fd8b85692768ff3ceb3885ad59836ceeb7b5#diff-437b1b031f7488e4c051cd111e665fe4b514cba5c64b9f2f23b9cd04aacd89bb
- https://www.sphinx-doc.org/en/master/usage/extensions/extlinks.html
- https://bugs.gentoo.org/892381