### PR TITLE
Add alias list

### DIFF
--- a/musicbrainzngs/mbxml.py
+++ b/musicbrainzngs/mbxml.py
@@ -503,6 +503,7 @@ def parse_recording(recording):
                  "rating": parse_rating,
                  "isrc-list": parse_external_id_list,
                  "relation-list": parse_relation_list,
+                 "alias-list": parse_alias_list,
                  "annotation": parse_annotation}
 
     result.update(parse_attributes(attribs, recording))

--- a/musicbrainzngs/mbxml.py
+++ b/musicbrainzngs/mbxml.py
@@ -481,6 +481,7 @@ def parse_release_group(rg):
                  "tag-list": parse_tag_list,
                  "user-tag-list": parse_tag_list,
                  "secondary-type-list": parse_element_list,
+                 "alias-list": parse_alias_list,
                  "relation-list": parse_relation_list,
                  "rating": parse_rating,
                  "annotation": parse_annotation}

--- a/musicbrainzngs/mbxml.py
+++ b/musicbrainzngs/mbxml.py
@@ -415,6 +415,7 @@ def parse_release(release):
                  "relation-list": parse_relation_list,
                  "annotation": parse_annotation,
                  "cover-art-archive": parse_caa,
+                 "alias-list": parse_alias_list,
                  "release-event-list": parse_release_event_list}
 
     result.update(parse_attributes(attribs, release))


### PR DESCRIPTION
This PR adds support for the `alias-list` field to `release`, `release-group` and `recording`